### PR TITLE
Respond to usernames, pr numbers, and issue numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### Unreleased
+
+#### External changes
+
+- Makes sure gh tool is installed.
+
+#### Internal changes
+
+- NA
+
 ### 0.1.1
 
 #### External changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ These initial releases have usable behavior, but may have some rough edges for s
 #### External changes
 
 - Makes sure gh tool is installed.
+- Show a `--help` message.
+- Works from a GitHub username, PR number, or issue number.
+- Clarify issue when PR activity call hangs.
+- Simplified README.
 
 #### Internal changes
 
-- NA
+- Use Click for CLI.
 
 ### 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,9 @@
 gh-profiler
 ===
 
-Like many, I've gotten waves of open source contributions where many of the new issues and PRs aren't worth engaging with. But it takes me a bit of time to sort through each of them.
+Many of us have received waves of open source contributions where many of the new "contributions" aren't worth engaging with. gh-profiler lets you quickly see a snapshot of the submitter's profile, and recent PR activity.
 
-People like to say that code should "speak for itself", but I've found that looking at a GitHub user's profile has been more helpful in making a quick determination about how much time to invest in the issue or PR. I typically look at a few quick things:
-
-- Has the person made an unusually high number of PRs lately?
-- Have a significant portion of these PRs been closed without merging?
-- Have they opened an excessive number of issues?
-- How old is the account?
-- Is there any meaningful information on their profile?
-
-I don't make a final decision about PRs and issues based on the answers to these questions, but many times I see enough red flags here that I have a good idea not to spend much time evaluating the contribution. (I'm mostly talking about PRs and issues where there's been no prior discussion, and there's a lot of text or changes in the PR/issue to review if I'm going to take it seriously.)
-
-The goal of this project is to get a quick snapshot of this kind of information, without having to do a bunch of clicking on GitHub. The output is a summary of what's found, with a quick visual cue as to which factors support investing time in the PR/issue, and which factors suggest it's better off being closed and ignored. I have no interest in calculating some kind of trust score, or any other single number.
+This meant to give you some quick context about how much to invest in reviewing the PR. It's not meant to give an immediate signal to close the PR or issue.
 
 Running as a tool
 ---

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ You can also install the project, and then run the bare `gh-profiler` command:
 
 ```sh
 (.venv) $ pip install gh-profiler
-Installed 1 package in 4ms
- + gh-profiler==0.1.0
 (.venv) $ gh-profiler ehmatthes
 
 GitHub user: ehmatthes

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ GitHub user: ehmatthes
   🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
 ```
 
+If you're working in your local project directory, you can simply provide a PR or issue number. The tool will look up the PR or issue, identify the user who opened it, and give a report on that user:
+
+```sh
+$ uvx gh-profiler 8
+
+GitHub user: ehmatthes
+  🟢 Account age: 5058 days
+  ...
+```
+
 Installing and then running
 ---
 
@@ -40,16 +50,7 @@ Installed 1 package in 4ms
 
 GitHub user: ehmatthes
   🟢 Account age: 5058 days
-
-  🟢 Profile information:
-      name: Eric Matthes
-      company:
-      blog: https://www.mostlypython.com
-      location: western North Carolina
-      email: ehmatthes@gmail.com
-      bio:
-
-  🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
+  ...
 ```
 
 When you've installed the project, you can also run it as a module:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gh-profiler"
 version = "0.1.1"
-description = "Examine a GitHub user's profile, and help quickly decide how much to invest in their contributions."
+description = "Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
 ]
 
 [project.scripts]
-gh-profiler = "gh_profiler.main:main"
+gh-profiler = "gh_profiler.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.1"
 description = "Examine a GitHub user's profile, and help quickly decide how much to invest in their contributions."
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "click>=8.3.3",
+]
 
 [project.scripts]
 gh-profiler = "gh_profiler.main:main"

--- a/src/gh_profiler/__main__.py
+++ b/src/gh_profiler/__main__.py
@@ -1,6 +1,6 @@
 """Allow project to run as a module."""
 
-from .main import main
+from .cli import main
 
 
 if __name__ == "__main__":

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -37,9 +37,6 @@ def _get_username(pr_issue_num):
     # Try as a PR.
     if username := _process_pr(pr_issue_num, repo_slug):
         return username
-    # if username is not None:
-    #     return username
-    
 
     # Then try as an issue.
     issue_cmd = (
@@ -74,12 +71,8 @@ def _get_repo_slug():
 
 def _process_pr(pr_issue_num, repo_slug):
     """See if this is a PR."""
-    pr_cmd = (
-        f'gh pr view {pr_issue_num} '
-        f'--repo {repo_slug} '
-        f'--json author '
-        f'--jq ".author.login"'
-    )
+    pr_cmd = f'gh pr view {pr_issue_num} --repo {repo_slug} --json author --jq ".author.login"'
+
     try:
         username = run_cmd(pr_cmd).strip()
         if username:

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -34,24 +34,14 @@ def _get_username(pr_issue_num):
     """Get the user that opened this PR/issue."""
     repo_slug = _get_repo_slug()
     
-    # Try as a PR.
+    # Try as a PR, then as an issue.
     if username := _process_pr(pr_issue_num, repo_slug):
         return username
+    if username := _process_issue(pr_issue_num, repo_slug):
+        return username
 
-    # Then try as an issue.
-    issue_cmd = (
-        f'gh issue view {pr_issue_num} '
-        f'--repo {repo_slug} '
-        f'--json author '
-        f'--jq ".author.login"'
-    )
-    try:
-        username = run_cmd(issue_cmd).strip()
-        if username:
-            return username
-    except Exception:
-        msg = f"Couldn't find a PR or issue #{pr_issue_num} in the repository {repo_slug}."
-        sys.exit(msg)
+    msg = f"Couldn't find a PR or issue #{pr_issue_num} in the repository {repo_slug}."
+    sys.exit(msg)
 
 def _get_repo_slug():
     """Parse `git remote -v` to identify GitHub project."""
@@ -80,3 +70,14 @@ def _process_pr(pr_issue_num, repo_slug):
     except Exception:
         # The number wasn't a PR.
         return None
+
+def _process_issue(pr_issue_num, repo_slug):
+    """See if this is an issue."""
+    issue_cmd = f'gh issue view {pr_issue_num} --repo {repo_slug} --json author --jq ".author.login"'
+    try:
+        username = run_cmd(issue_cmd).strip()
+        if username:
+            return username
+    except Exception:
+        msg = f"Couldn't find a PR or issue #{pr_issue_num} in the repository {repo_slug}."
+        sys.exit(msg)

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -35,9 +35,10 @@ def _get_username(pr_issue_num):
     repo_slug = _get_repo_slug()
     
     # Try as a PR.
-    username = _process_pr(pr_issue_num, repo_slug)
-    if username is not None:
+    if username := _process_pr(pr_issue_num, repo_slug):
         return username
+    # if username is not None:
+    #     return username
     
 
     # Then try as an issue.

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -13,7 +13,7 @@ from .utils.infra_utils import run_cmd
 @click.command()
 @click.argument("target")
 def main(target):
-    """Process user's gh-profiler command."""
+    """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions."""
 
     # If the main argument is an integer, process the PR/issue number.
     # Otherwise, assume it's the username.

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -32,18 +32,8 @@ def main(target):
 
 def _get_username(pr_issue_num):
     """Get the user that opened this PR/issue."""
-    remote_output = run_cmd("git remote -v")
-    match = re.search(
-        r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^.\s]+)(?:\.git)?\s",
-        remote_output,
-    )
-    if not match:
-        msg = f"Couldn't determine appropriate required information from `git remote -v`."
-        sys.exit(msg)
-
-    owner = match.group("owner")
-    repo = match.group("repo")
-    repo_slug = f"{owner}/{repo}"
+    repo_slug = _get_repo_slug()
+    
 
     # See if this is a PR.
     pr_cmd = (
@@ -75,3 +65,19 @@ def _get_username(pr_issue_num):
     except Exception:
         msg = f"Couldn't find a PR or issue #{pr_issue_num} in the repository {repo_slug}."
         sys.exit(msg)
+
+def _get_repo_slug():
+    """Parse `git remote -v` to identify GitHub project."""
+    remote_output = run_cmd("git remote -v")
+    match = re.search(
+        r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^.\s]+)(?:\.git)?\s",
+        remote_output,
+    )
+    if not match:
+        msg = f"Couldn't determine appropriate required information from `git remote -v`."
+        sys.exit(msg)
+
+    owner = match.group("owner")
+    repo = match.group("repo")
+
+    return f"{owner}/{repo}"

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -1,0 +1,11 @@
+"""Main CLI entry point for gh-profiler."""
+
+import click
+
+from . import gh_profiler
+
+
+@click.command()
+@click.argument("target")
+def main(target):
+    gh_profiler.main(target)

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -62,21 +62,18 @@ def _get_repo_slug():
 def _process_pr(pr_issue_num, repo_slug):
     """See if this is a PR."""
     pr_cmd = f'gh pr view {pr_issue_num} --repo {repo_slug} --json author --jq ".author.login"'
-
     try:
-        username = run_cmd(pr_cmd).strip()
-        if username:
+        if username := run_cmd(pr_cmd).strip():
             return username
-    except Exception:
-        # The number wasn't a PR.
+    except Exception as e:
+        breakpoint()
         return None
 
 def _process_issue(pr_issue_num, repo_slug):
     """See if this is an issue."""
     issue_cmd = f'gh issue view {pr_issue_num} --repo {repo_slug} --json author --jq ".author.login"'
     try:
-        username = run_cmd(issue_cmd).strip()
-        if username:
+        if username := run_cmd(issue_cmd).strip():
             return username
     except Exception:
         msg = f"Couldn't find a PR or issue #{pr_issue_num} in the repository {repo_slug}."

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -18,9 +18,13 @@ def main(target):
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
 
     \b
-    Examples:
+    Usage as a tool:
     $ uvx gh-profiler ehmatthes
     $ uvx gh-profiler 8
+
+    \b
+    Usage when installing gh-profiler:
+    $ gh-profiler ehmatthes
     $ python -m gh_profiler ehmatthes
       ...
     """

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -13,7 +13,17 @@ from .utils.infra_utils import run_cmd
 @click.command()
 @click.argument("target")
 def main(target):
-    """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions."""
+    """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
+    
+    You can target a GitHub username, or a PR/issue number from the repository you're working in.
+
+    \b
+    Examples:
+    $ uvx gh-profiler ehmatthes
+    $ uvx gh-profiler 8
+    $ python -m gh_profiler ehmatthes
+      ...
+    """
 
     # If the main argument is an integer, process the PR/issue number.
     # Otherwise, assume it's the username.

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -34,22 +34,11 @@ def _get_username(pr_issue_num):
     """Get the user that opened this PR/issue."""
     repo_slug = _get_repo_slug()
     
-
-    # See if this is a PR.
-    pr_cmd = (
-        f'gh pr view {pr_issue_num} '
-        f'--repo {repo_slug} '
-        f'--json author '
-        f'--jq ".author.login"'
-    )
-    try:
-        username = run_cmd(pr_cmd).strip()
-        if username:
-            return username
-
-    except Exception:
-        # The number wasn't a PR.
-        pass
+    # Try as a PR.
+    username = _process_pr(pr_issue_num, repo_slug)
+    if username is not None:
+        return username
+    
 
     # Then try as an issue.
     issue_cmd = (
@@ -81,3 +70,19 @@ def _get_repo_slug():
     repo = match.group("repo")
 
     return f"{owner}/{repo}"
+
+def _process_pr(pr_issue_num, repo_slug):
+    """See if this is a PR."""
+    pr_cmd = (
+        f'gh pr view {pr_issue_num} '
+        f'--repo {repo_slug} '
+        f'--json author '
+        f'--jq ".author.login"'
+    )
+    try:
+        username = run_cmd(pr_cmd).strip()
+        if username:
+            return username
+    except Exception:
+        # The number wasn't a PR.
+        return None

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -8,4 +8,23 @@ from . import gh_profiler
 @click.command()
 @click.argument("target")
 def main(target):
-    gh_profiler.main(target)
+    """Process user's gh-profiler command."""
+
+    # If the main argument is an integer, process the PR/issue number.
+    # Otherwise, assume it's the username.
+    try:
+        pr_issue_num = int(target)
+    except ValueError:
+        gh_profiler.main(target)
+    
+    # The user provided a PR/issue number. Get the relevant username, then
+    # call gh_profiler.main().
+    username = _get_username(pr_issue_num)
+    gh_profiler.main(username)
+
+
+# --- Helper functions ---
+
+def _get_username(pr_issue_num):
+    """Get the user that opened this PR/issue."""
+    ...

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -1,8 +1,13 @@
 """Main CLI entry point for gh-profiler."""
 
+import json
+import re
+import sys
+
 import click
 
 from . import gh_profiler
+from .utils.infra_utils import run_cmd
 
 
 @click.command()
@@ -27,4 +32,46 @@ def main(target):
 
 def _get_username(pr_issue_num):
     """Get the user that opened this PR/issue."""
-    ...
+    remote_output = run_cmd("git remote -v")
+    match = re.search(
+        r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^.\s]+)(?:\.git)?\s",
+        remote_output,
+    )
+    if not match:
+        msg = f"Couldn't determine appropriate required information from `git remote -v`."
+        sys.exit(msg)
+
+    owner = match.group("owner")
+    repo = match.group("repo")
+    repo_slug = f"{owner}/{repo}"
+
+    # See if this is a PR.
+    pr_cmd = (
+        f'gh pr view {pr_issue_num} '
+        f'--repo {repo_slug} '
+        f'--json author '
+        f'--jq ".author.login"'
+    )
+    try:
+        username = run_cmd(pr_cmd).strip()
+        if username:
+            return username
+
+    except Exception:
+        # The number wasn't a PR.
+        pass
+
+    # Then try as an issue.
+    issue_cmd = (
+        f'gh issue view {pr_issue_num} '
+        f'--repo {repo_slug} '
+        f'--json author '
+        f'--jq ".author.login"'
+    )
+    try:
+        username = run_cmd(issue_cmd).strip()
+        if username:
+            return username
+    except Exception:
+        msg = f"Couldn't find a PR or issue #{pr_issue_num} in the repository {repo_slug}."
+        sys.exit(msg)

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -6,18 +6,15 @@ to invest in reviewing PRs, and general interaction on open source projects.
 
 import sys
 
-import click
-
 from .utils.profile_data import profile_data as pdata
 from .utils import profile_utils
 from .utils import analysis_utils
 from .utils import summary_utils
 
 
-@click.command()
-@click.argument("target")
-def main(target):
-    pdata.username = target
+def main(gh_user):
+    pdata.username = gh_user
+
     # Make sure gh is available.
     profile_utils.ensure_gh()
 
@@ -36,7 +33,3 @@ def main(target):
 
     # Summarize findings.
     summary_utils.show_summary()
-
-
-if __name__ == "__main__":
-    main()

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -33,3 +33,6 @@ def main(gh_user):
 
     # Summarize findings.
     summary_utils.show_summary()
+
+    # Finished, don't return control to cli.py.
+    sys.exit()

--- a/src/gh_profiler/main.py
+++ b/src/gh_profiler/main.py
@@ -17,6 +17,9 @@ pdata.username = gh_user
 
 
 def main():
+    # Make sure gh is available.
+    profile_utils.ensure_gh()
+
     # Get all information we'll need about the user's profile.
     profile_utils.get_profile_info()
 

--- a/src/gh_profiler/main.py
+++ b/src/gh_profiler/main.py
@@ -6,17 +6,18 @@ to invest in reviewing PRs, and general interaction on open source projects.
 
 import sys
 
+import click
+
 from .utils.profile_data import profile_data as pdata
 from .utils import profile_utils
 from .utils import analysis_utils
 from .utils import summary_utils
 
 
-gh_user = sys.argv[1]
-pdata.username = gh_user
-
-
-def main():
+@click.command()
+@click.argument("gh_user")
+def main(gh_user):
+    pdata.username = gh_user
     # Make sure gh is available.
     profile_utils.ensure_gh()
 

--- a/src/gh_profiler/main.py
+++ b/src/gh_profiler/main.py
@@ -15,9 +15,9 @@ from .utils import summary_utils
 
 
 @click.command()
-@click.argument("gh_user")
-def main(gh_user):
-    pdata.username = gh_user
+@click.argument("target")
+def main(target):
+    pdata.username = target
     # Make sure gh is available.
     profile_utils.ensure_gh()
 

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -41,6 +41,13 @@ def get_pr_activity():
     )
     closed_cmd = f'gh api "search/issues?q={quote(base_query + " is:closed -is:merged")}" --jq .total_count'
 
-    pdata.opened_count = int(infra_utils.run_cmd(opened_cmd).strip())
-    pdata.merged_count = int(infra_utils.run_cmd(merged_cmd).strip())
-    pdata.closed_count = int(infra_utils.run_cmd(closed_cmd).strip())
+    # DEV: These calls seem to be timing out occasionally.
+    try:
+        pdata.opened_count = int(infra_utils.run_cmd(opened_cmd).strip())
+        pdata.merged_count = int(infra_utils.run_cmd(merged_cmd).strip())
+        pdata.closed_count = int(infra_utils.run_cmd(closed_cmd).strip())
+    except ValueError:
+        msg = "Couldn't get recent PR activity. The gh CLI may have timed out."
+        msg += "\n  You may want to try running the command again."
+        sys.exit(msg)
+

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -5,10 +5,23 @@ from datetime import datetime as dt
 from datetime import timezone as tz
 from datetime import timedelta
 from urllib.parse import quote
+import sys
 
 from .profile_data import profile_data as pdata
 from . import infra_utils
 
+def ensure_gh():
+    """Make sure user has gh installed.
+    
+    DEV: This may need different implementation on Windows or Linux.
+    """
+    cmd = "gh --version"
+    try:
+        version_info = infra_utils.run_cmd(cmd)
+    except FileNotFoundError:
+        msg = "The GitHub CLI tool (gh) must be installed."
+        msg += "\n  https://cli.github.com"
+        sys.exit(msg)
 
 def get_profile_info():
     """Get all the profile info we'll need."""

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,33 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "gh-profiler"
 version = "0.1.1"
 source = { editable = "." }
+dependencies = [
+    { name = "click" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "click", specifier = ">=8.3.3" }]


### PR DESCRIPTION
Update the project to work from a username, issue number, or pr number. If a number is provided, query the gh cli for the relevant pr/issue, and grab the username from that info. Also cleans up CLI.