### PR TITLE
Better error if GitHub username not found

### DIFF
--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -28,6 +28,8 @@ def get_profile_info():
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
     profile_info = infra_utils.run_cmd(cmd)
     pdata.profile_info = json.loads(profile_info)
+    if "created_at" not in pdata.profile_info:
+        sys.exit(f"GitHub user '{pdata.username}' not found.")
 
 
 def get_pr_activity():


### PR DESCRIPTION
Before (I miscopied and pasted):

```pytb
❯ uvx gh-profiler ehmatthe
Traceback (most recent call last):
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/gh_profiler/cli.py", line 35, in main
    pr_issue_num = int(target)
ValueError: invalid literal for int() with base 10: 'ehmatthe'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/bin/gh-profiler", line 12, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/gh_profiler/cli.py", line 37, in main
    gh_profiler.main(target)
    ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/gh_profiler/gh_profiler.py", line 25, in main
    analysis_utils.process_account_age()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/gh_profiler/utils/analysis_utils.py", line 12, in process_account_age
    ts_created = dt.fromisoformat(pdata.profile_info["created_at"])
                                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'created_at'
```

After:

```console
❯ gh-profiler ehmatthe
GitHub user 'ehmatthe' not found.
```
