### PR TITLE
Better error if `gh` not authenticated

### DIFF
--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -11,8 +11,8 @@ from .profile_data import profile_data as pdata
 from . import infra_utils
 
 def ensure_gh():
-    """Make sure user has gh installed.
-    
+    """Make sure user has gh installed and is authenticated.
+
     DEV: This may need different implementation on Windows or Linux.
     """
     cmd = "gh --version"
@@ -21,6 +21,12 @@ def ensure_gh():
     except FileNotFoundError:
         msg = "The GitHub CLI tool (gh) must be installed."
         msg += "\n  https://cli.github.com"
+        sys.exit(msg)
+
+    cmd = "gh api user --jq .login"
+    if not infra_utils.run_cmd(cmd).strip():
+        msg = "The GitHub CLI tool (gh) is not authenticated."
+        msg += "\n  Run: gh auth login"
         sys.exit(msg)
 
 def get_profile_info():


### PR DESCRIPTION
If `gh` isn't installed, we get a nice error message:

```console
❯ uvx gh-profiler ehmatthes
The GitHub CLI tool (gh) must be installed.
  https://cli.github.com
```


But if it's not yet authenticated, we get a traceback. Let's improve it.

Before:

```pytb
❯ uvx gh-profiler ehmatthes
Traceback (most recent call last):
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/bin/gh-profiler", line 12, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/gh_profiler/cli.py", line 37, in main
    gh_profiler.main(target)
    ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/gh_profiler/gh_profiler.py", line 22, in main
    profile_utils.get_profile_info()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/hugo/.cache/uv/archive-v0/cF5884_RiZewxzBwWODy7/lib/python3.14/site-packages/gh_profiler/utils/profile_utils.py", line 30, in get_profile_info
    pdata.profile_info = json.loads(profile_info)
                         ~~~~~~~~~~^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/json/__init__.py", line 352, in loads
    return _default_decoder.decode(s)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/json/decoder.py", line 345, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/json/decoder.py", line 363, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After:

```console
❯ gh-profiler ehmatthes
The GitHub CLI tool (gh) is not authenticated.
  Run: gh auth login
```
