### PR TITLE
Use `gh`'s default remote, rather than taking the first remote

### DIFF
--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -1,7 +1,6 @@
 """Main CLI entry point for gh-profiler."""
 
 import json
-import re
 import sys
 
 import click
@@ -58,20 +57,15 @@ def _get_username(pr_issue_num):
     sys.exit(msg)
 
 def _get_repo_slug():
-    """Parse `git remote -v` to identify GitHub project."""
-    remote_output = run_cmd("git remote -v")
-    match = re.search(
-        r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^.\s]+)(?:\.git)?\s",
-        remote_output,
-    )
-    if not match:
-        msg = f"Couldn't determine appropriate required information from `git remote -v`."
+    """Ask `gh` for the resolved default repo (honors `gh repo set-default`)."""
+    slug = run_cmd("gh repo view --json nameWithOwner --jq .nameWithOwner").strip()
+    if not slug:
+        msg = (
+            "Couldn't determine the default GitHub repository. "
+            "Run `gh repo set-default` in this directory and try again."
+        )
         sys.exit(msg)
-
-    owner = match.group("owner")
-    repo = match.group("repo")
-
-    return f"{owner}/{repo}"
+    return slug
 
 def _process_pr(pr_issue_num, repo_slug):
     """See if this is a PR."""


### PR DESCRIPTION
If I'm working in a fork, for example hugovk/cpython is a fork of python/cpython, I usually have `gh` set the upstream as the default:

```console
❯ gh repo set-default --help
This command sets the default remote repository to use when querying the
GitHub API for the locally cloned repository.

gh uses the default repository for things like:

 - viewing and creating pull requests
 - viewing and creating issues
 - viewing and creating releases
 - working with GitHub Actions
```

So for example, when I do `gh co 149190`, it checks out the branch from the upstream repo.

However, right now, if I use an upstream issue number:

```console
❯ gh-profiler 149190
Couldn't find a PR or issue #149190 in the repository hugovk/cpython.
```

It's looking at the remotes and picking the first.

Instead, we can also use the remote from `gh`:


```console
❯ gh-profiler 149190

GitHub user: hugovk
  🟢 Account age: 5222 days

  🟢 Profile information:
      name: Hugo van Kemenade
      [and so on]
```

This also works in a repo with a single remote.