### PR TITLE
Don't analyze PR activity for fewer than 10 opened PRs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These initial releases have usable behavior, but may have some rough edges for s
 - @hugovk was right, `created_at` is a better check than `status`. `status` not present for valid users. (#11)
 - Ensure that gh CLI tool is authenticated before running. (#12)
 - Use gh's default remote, rather than parsing output of `git remote -v` and taking first result. (#13)
+- If a user has opened fewer than 10 PRs recently, don't analyze PR activity. Fixes zero division error bug from #14.
 
 #### Internal changes
 

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -38,6 +38,10 @@ def process_profile_info():
 
 def process_pr_activity():
     """Evaluate recent PR activity."""
+    # Don't need to analyze PR activity if fewer than 10 PRs opened recently.
+    if pdata.opened_count < 10:
+        return
+
     ratio_merged = pdata.merged_count / pdata.opened_count
     ratio_closed = pdata.closed_count / pdata.opened_count
 


### PR DESCRIPTION
Fixes #14.