### PR TITLE
Fix NameError: name 'yellow_flag' is not defined

### DIFF
--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -15,7 +15,7 @@ def process_account_age():
     if pdata.account_age.days > 3 * 365:
         pdata.flag_age = flags.green_flag
     elif pdata.account_age.days > 90:
-        pdata.flag_age = yellow_flag
+        pdata.flag_age = flags.yellow_flag
     else:
         pdata.flag_age = flags.red_flag
 


### PR DESCRIPTION
Fixes:
```pytb
❯ gh-profiler nweinb
Traceback (most recent call last):
  File "/private/tmp/gh-profiler/src/gh_profiler/cli.py", line 35, in main
    pr_issue_num = int(target)
ValueError: invalid literal for int() with base 10: 'nweinb'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.14/bin/gh-profiler", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/private/tmp/gh-profiler/src/gh_profiler/cli.py", line 37, in main
    gh_profiler.main(target)
    ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/private/tmp/gh-profiler/src/gh_profiler/gh_profiler.py", line 25, in main
    analysis_utils.process_account_age()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/private/tmp/gh-profiler/src/gh_profiler/utils/analysis_utils.py", line 18, in process_account_age
    pdata.flag_age = yellow_flag
                     ^^^^^^^^^^^
NameError: name 'yellow_flag' is not defined
```

To get:
```console
❯ gh-profiler nweinb

GitHub user: nweinb
  🟡 Account age: 598 days

  🔴 No profile information has been provided.

  🟢 nweinb has opened fewer than 10 PRs in the last 21 days.
```
