### PR TITLE
Don't print individual lines for empty profile fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ Maintaining
 ### Add/ modify a requirement
 
 - Add or modify a requirement by modifying pyproject.toml, or running `uv add <package>`.
+- For a dev dependency, run `uv add --dev <package>`.
 - Then run `uv lock`.
+
+Running tests
+---
+
+```sh
+$ uv run pytest
+```
 
 New releases
 ---

--- a/README.md
+++ b/README.md
@@ -12,17 +12,15 @@ If you have uv installed, you can run this as a tool against any GitHub user:
 
 ```sh
 $ uvx gh-profiler ehmatthes
-
 GitHub user: ehmatthes
   🟢 Account age: 5058 days
 
   🟢 Profile information:
       name: Eric Matthes
-      company:
       blog: https://www.mostlypython.com
       location: western North Carolina
       email: ehmatthes@gmail.com
-      bio:
+     empty fields: company, bio
 
   🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
 ```
@@ -31,7 +29,6 @@ If you're working in your local project directory, you can simply provide a PR o
 
 ```sh
 $ uvx gh-profiler 8
-
 GitHub user: ehmatthes
   🟢 Account age: 5058 days
   ...
@@ -45,7 +42,6 @@ You can also install the project, and then run the bare `gh-profiler` command:
 ```sh
 (.venv) $ pip install gh-profiler
 (.venv) $ gh-profiler ehmatthes
-
 GitHub user: ehmatthes
   🟢 Account age: 5058 days
   ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,8 @@ gh-profiler = "gh_profiler.cli:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -21,10 +21,7 @@ def _get_summary():
     summary += f"  {pdata.flag_age} Account age: {pdata.account_age.days} days\n"
 
     # Available profile information:
-    if pdata.flag_profile == flags.red_flag:
-        summary += f"\n  {pdata.flag_profile} No profile information has been provided.\n"
-    else:
-        summary += _get_profile_summary()
+    summary += _get_profile_summary()
     
     # Recent PR activity:
     summary += "\n"
@@ -44,6 +41,9 @@ def _get_summary():
 
 def _get_profile_summary():
     """Summarize information from the user's profile dict."""
+    if pdata.flag_profile == flags.red_flag:
+        return f"\n  {pdata.flag_profile} No profile information has been provided.\n"
+
     summary = f"\n  {pdata.flag_profile} Profile information:\n"
 
     for k, v in pdata.profile_dict.items():

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -61,14 +61,15 @@ def _bio_summary(bio):
 
 def _pr_activity_summary():
     """Summarize recent PR activity."""
+    if pdata.opened_count < 10:
+        return f"  {flags.green_flag} {pdata.username} has opened fewer than 10 PRs in the last 21 days.\n"
+
     summary = ""
-    if pdata.opened_count >= 10:
-        # Only show merged if it's a good sign.
-        if pdata.flag_merged_pr == flags.green_flag:
-            summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs have been merged in the last 21 days.\n"
-        summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs have been closed without merging in the last 21 days.\n"
-    else:
-        summary += f"  {flags.green_flag} {pdata.username} has opened fewer than 10 PRs in the last 21 days.\n"
+    # Only show merged if it's a good sign.
+    if pdata.flag_merged_pr == flags.green_flag:
+        summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs have been merged in the last 21 days.\n"
+    
+    # Include number closed for everyone.
+    summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs have been closed without merging in the last 21 days.\n"
 
     return summary
-    

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -20,22 +20,12 @@ def _get_summary():
     summary += f"GitHub user: {pdata.username}\n"
     summary += f"  {pdata.flag_age} Account age: {pdata.account_age.days} days\n"
 
-    # Available profile information:
     summary += _profile_summary()
+    summary += "\n"
+    summary += _pr_activity_summary()
+    summary += "\n"
     
-    # Recent PR activity:
-    summary += "\n"
-    if pdata.opened_count >= 10:
-        # Only show merged if it's a good sign.
-        if pdata.flag_merged_pr == flags.green_flag:
-            summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs have been merged in the last 21 days.\n"
-        summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs have been closed without merging in the last 21 days.\n"
-    else:
-        summary += f"  {flags.green_flag} {pdata.username} has opened fewer than 10 PRs in the last 21 days.\n"
-    summary += "\n"
-
     return summary
-
 
 # --- Helper functions ---
 
@@ -45,7 +35,6 @@ def _profile_summary():
         return f"\n  {pdata.flag_profile} No profile information has been provided.\n"
 
     summary = f"\n  {pdata.flag_profile} Profile information:\n"
-
     for k, v in pdata.profile_dict.items():
         if v and k != "bio":
             summary += f"      {k}: {v}\n"
@@ -57,10 +46,10 @@ def _profile_summary():
     return summary
 
 def _bio_summary(bio):
-    """Show a bio appropriately."""
+    """Summarize bio section of profile."""
     if bio in (None, ""):
         return f"      bio:\n"
-        
+
     if bio.count("\n") == 0:
         return f"      bio: {bio}\n"
 
@@ -69,3 +58,17 @@ def _bio_summary(bio):
     for line in bio.splitlines():
         summary += f"        {line}\n"
     return summary
+
+def _pr_activity_summary():
+    """Summarize recent PR activity."""
+    summary = ""
+    if pdata.opened_count >= 10:
+        # Only show merged if it's a good sign.
+        if pdata.flag_merged_pr == flags.green_flag:
+            summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs have been merged in the last 21 days.\n"
+        summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs have been closed without merging in the last 21 days.\n"
+    else:
+        summary += f"  {flags.green_flag} {pdata.username} has opened fewer than 10 PRs in the last 21 days.\n"
+
+    return summary
+    

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -6,59 +6,66 @@ from . import flags
 
 def show_summary():
     """Show a concise summary of what was found."""
+    summary = _get_summary()
+    print(summary)
+
+def _get_summary():
+    """Build a summary string.
+
+    This is more testable and flexible than just printing each bit of information.
+    """
+    summary = ""
+
     # Username, account age:
-    print(f"\nGitHub user: {pdata.username}")
-    print(f"  {pdata.flag_age} Account age: {pdata.account_age.days} days")
+    summary += f"GitHub user: {pdata.username}\n"
+    summary += f"  {pdata.flag_age} Account age: {pdata.account_age.days} days\n"
 
     # Available profile information:
     if pdata.flag_profile == flags.red_flag:
-        print(f"\n  {pdata.flag_profile} No profile information has been provided.")
+        summary += f"\n  {pdata.flag_profile} No profile information has been provided.\n"
     else:
-        _show_profile_dict()
+        summary += _get_profile_summary()
     
     # Recent PR activity:
-    print()
+    summary += "\n"
     if pdata.opened_count >= 10:
         # Only show merged if it's a good sign.
         if pdata.flag_merged_pr == flags.green_flag:
-            print(
-                f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs have been merged in the last 21 days."
-            )
-        print(
-            f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs have been closed without merging in the last 21 days."
-        )
+            summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs have been merged in the last 21 days.\n"
+        summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs have been closed without merging in the last 21 days.\n"
     else:
-        print(
-            f"  {flags.green_flag} {pdata.username} has opened fewer than 10 PRs in the last 21 days."
-        )
-    print("")
+        summary += f"  {flags.green_flag} {pdata.username} has opened fewer than 10 PRs in the last 21 days.\n"
+    summary += "\n"
+
+    return summary
 
 
 # --- Helper functions ---
 
-def _show_profile_dict():
+def _get_profile_summary():
     """Summarize information from the user's profile dict."""
-    print(f"\n  {pdata.flag_profile} Profile information:")
+    summary = f"\n  {pdata.flag_profile} Profile information:\n"
 
     for k, v in pdata.profile_dict.items():
         if v and k != "bio":
-            print(f"      {k}: {v}")
+            summary += f"      {k}: {v}\n"
         elif k == "bio":
-            _show_bio(v)
+            summary += _get_bio(v)
         else:
-            print(f"      {k}:")
+            summary += f"      {k}:\n"
 
-def _show_bio(bio):
+    return summary
+
+def _get_bio(bio):
     """Show a bio appropriately."""
     if bio in (None, ""):
-        print(f"      bio:")
-        return
+        return f"      bio:\n"
         
     if bio.count("\n") == 0:
-        print(f"      bio: {bio}")
-        return
+        return f"      bio: {bio}\n"
 
     # Print a multi-line bio.
-    print("      bio:")
+    summary = "      bio:\n"
     for line in bio.splitlines():
-        print(f"        {line}")
+        summary += f"        {line}\n"
+    return summary

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -25,7 +25,7 @@ def _get_summary():
     summary += _pr_activity_summary()
     summary += "\n"
     
-    return summary
+    return summary.strip()
 
 # --- Helper functions ---
 

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -21,7 +21,7 @@ def _get_summary():
     summary += f"  {pdata.flag_age} Account age: {pdata.account_age.days} days\n"
 
     # Available profile information:
-    summary += _get_profile_summary()
+    summary += _profile_summary()
     
     # Recent PR activity:
     summary += "\n"
@@ -39,7 +39,7 @@ def _get_summary():
 
 # --- Helper functions ---
 
-def _get_profile_summary():
+def _profile_summary():
     """Summarize information from the user's profile dict."""
     if pdata.flag_profile == flags.red_flag:
         return f"\n  {pdata.flag_profile} No profile information has been provided.\n"
@@ -50,13 +50,13 @@ def _get_profile_summary():
         if v and k != "bio":
             summary += f"      {k}: {v}\n"
         elif k == "bio":
-            summary += _get_bio(v)
+            summary += _bio_summary(v)
         else:
             summary += f"      {k}:\n"
 
     return summary
 
-def _get_bio(bio):
+def _bio_summary(bio):
     """Show a bio appropriately."""
     if bio in (None, ""):
         return f"      bio:\n"

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -34,14 +34,22 @@ def _profile_summary():
     if pdata.flag_profile == flags.red_flag:
         return f"\n  {pdata.flag_profile} No profile information has been provided.\n"
 
+    # Only show lines for fields that have information.
+    # Collect empty fields for last line.
     summary = f"\n  {pdata.flag_profile} Profile information:\n"
+    empty_fields = []
     for k, v in pdata.profile_dict.items():
         if v and k != "bio":
             summary += f"      {k}: {v}\n"
-        elif k == "bio":
+        elif v and k == "bio":
             summary += _bio_summary(v)
         else:
-            summary += f"      {k}:\n"
+            empty_fields.append(k)
+
+    # List empty fields.
+    if empty_fields:
+        fields_str = ", ".join(empty_fields)
+        summary += f"     empty fields: {fields_str}\n"
 
     return summary
 

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -1,0 +1,16 @@
+"""Reference output for testing summary."""
+
+full_summary = """
+GitHub user: ehmatthes
+  🟢 Account age: 5058 days
+
+  🟢 Profile information:
+      name: Eric Matthes
+      company:
+      blog: https://www.mostlypython.com
+      location: western North Carolina
+      email: ehmatthes@gmail.com
+      bio:
+
+  🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
+""".strip()

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -14,3 +14,12 @@ GitHub user: ehmatthes
 
   🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
 """.strip()
+
+summary_empty_profile = """
+GitHub user: ehmatthes
+  🟢 Account age: 5058 days
+
+  🔴 No profile information has been provided.
+
+  🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
+""".strip()

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -6,11 +6,10 @@ GitHub user: ehmatthes
 
   🟢 Profile information:
       name: Eric Matthes
-      company:
       blog: https://www.mostlypython.com
       location: western North Carolina
       email: ehmatthes@gmail.com
-      bio:
+     empty fields: company, bio
 
   🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
 """.strip()

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -1,0 +1,40 @@
+"""Tests for the summary that's generated."""
+
+from datetime import timedelta
+
+from gh_profiler.utils import summary_utils
+from gh_profiler.utils.profile_data import profile_data as pdata
+from gh_profiler.utils import flags
+from reference_files import reference_summaries
+
+
+
+def test_summary():
+    """Test the overall summary output.
+    
+    DEV: Consider processing the profile data, instead of setting it?
+         Maybe that's an integration test?
+         Maybe unit test the processing function?
+    """
+    pdata.username = "ehmatthes"
+    pdata.profile_info = {
+        "name": "Eric Matthes",
+        "company": None,
+        "blog": "https://www.mostlypython.com",
+        "location": "western North Carolina",
+        "email": "ehmatthes@gmail.com",
+        "bio": None,
+    }
+    pdata.opened_count = 5
+    pdata.closed_count = 1
+    pdata.merged_count = 3
+    pdata.account_age = timedelta(days=5058)
+    pdata.flag_age = flags.green_flag
+    pdata.flag_profile = flags.green_flag
+
+    # This is taken from analysis_utils.py:
+    fields = ["name", "company", "blog", "location", "email", "bio"]
+    pdata.profile_dict = {field:pdata.profile_info[field] for field in fields}
+
+    summary = summary_utils._get_summary()
+    assert summary.strip() == reference_summaries.full_summary

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -2,20 +2,16 @@
 
 from datetime import timedelta
 
+import pytest
+
 from gh_profiler.utils import summary_utils
 from gh_profiler.utils.profile_data import profile_data as pdata
 from gh_profiler.utils import flags
 from reference_files import reference_summaries
 
-
-
-def test_summary():
-    """Test the overall summary output.
-    
-    DEV: Consider processing the profile data, instead of setting it?
-         Maybe that's an integration test?
-         Maybe unit test the processing function?
-    """
+@pytest.fixture()
+def filled_pdata():
+    """Fill in a basic pdata profile."""
     pdata.username = "ehmatthes"
     pdata.profile_info = {
         "name": "Eric Matthes",
@@ -36,5 +32,12 @@ def test_summary():
     fields = ["name", "company", "blog", "location", "email", "bio"]
     pdata.profile_dict = {field:pdata.profile_info[field] for field in fields}
 
+def test_summary(filled_pdata):
+    """Test the overall summary output.
+    
+    DEV: Consider processing the profile data, instead of setting it?
+         Maybe that's an integration test?
+         Maybe unit test the processing function?
+    """
     summary = summary_utils._get_summary()
     assert summary.strip() == reference_summaries.full_summary

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -43,6 +43,17 @@ def filled_pdata():
     fields = ["name", "company", "blog", "location", "email", "bio"]
     pdata.profile_dict = {field:pdata.profile_info[field] for field in fields}
 
+@pytest.fixture()
+def empty_profile_info():
+    """Empty the profile dict.
+
+    Tests that need this will need to include this fixture explicitly.
+    This can simplify some more specific profile tests.
+    """
+    pdata.profile_info = {}
+    pdata.flag_profile = flags.red_flag
+
+
 
 # --- Test functions ---
 
@@ -56,10 +67,7 @@ def test_summary():
     summary = summary_utils._get_summary()
     assert summary.strip() == reference_summaries.full_summary
 
-def test_summary_empty_profile():
+def test_summary_empty_profile(empty_profile_info):
     """Test summary for user with an empty profile."""
-    pdata.profile_info = {}
-    pdata.flag_profile = flags.red_flag
-
     summary = summary_utils._get_summary()
     assert summary.strip() == reference_summaries.summary_empty_profile

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -9,9 +9,20 @@ from gh_profiler.utils.profile_data import profile_data as pdata
 from gh_profiler.utils import flags
 from reference_files import reference_summaries
 
-@pytest.fixture()
+
+# --- Fixtures ---
+
+@pytest.fixture(autouse=True)
 def filled_pdata():
-    """Fill in a basic pdata profile."""
+    """Fill in a basic pdata profile.
+
+    This fixture doesn't need to be passed, because it modifies the singleton
+    pdata object.
+    
+    DEV: Consider processing the profile data, instead of setting it?
+         Maybe that's an integration test?
+         Maybe unit test the processing function?
+    """
     pdata.username = "ehmatthes"
     pdata.profile_info = {
         "name": "Eric Matthes",
@@ -32,7 +43,10 @@ def filled_pdata():
     fields = ["name", "company", "blog", "location", "email", "bio"]
     pdata.profile_dict = {field:pdata.profile_info[field] for field in fields}
 
-def test_summary(filled_pdata):
+
+# --- Test functions ---
+
+def test_summary():
     """Test the overall summary output.
     
     DEV: Consider processing the profile data, instead of setting it?
@@ -41,3 +55,11 @@ def test_summary(filled_pdata):
     """
     summary = summary_utils._get_summary()
     assert summary.strip() == reference_summaries.full_summary
+
+def test_summary_empty_profile():
+    """Test summary for user with an empty profile."""
+    pdata.profile_info = {}
+    pdata.flag_profile = flags.red_flag
+
+    summary = summary_utils._get_summary()
+    assert summary.strip() == reference_summaries.summary_empty_profile

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "gh-profiler"
 version = "0.2.4"
 source = { editable = "." }
@@ -31,5 +43,130 @@ dependencies = [
     { name = "click" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "click", specifier = ">=8.3.3" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
Also:

- Build summary string and then print that string, instead of using a series of print calls.
- Helper functions to build sections of summary.
- Initial unit tests for `_get_summary()`.
- Simpler logic for generating summary sections.