### PR TITLE
Strip ASCII color codes from `gh` output.

### DIFF
--- a/src/gh_profiler/utils/infra_utils.py
+++ b/src/gh_profiler/utils/infra_utils.py
@@ -3,9 +3,14 @@ import os
 import shlex
 import subprocess
 
+DEFAULT_ENV = {
+        **os.environ,
+        'CLICOLOR_FORCE': '0',
+        'NO_COLOR': '1',
+    }
 
-def run_cmd(cmd, env=None):
+def run_cmd(cmd, env = DEFAULT_ENV):
     """Run a subprocess command, return stdout."""
     cmd_parts = shlex.split(cmd)
-    output_obj = subprocess.run(cmd_parts, capture_output=True, env=env or os.environ)
+    output_obj = subprocess.run(cmd_parts, capture_output=True, env=env)
     return output_obj.stdout.decode()

--- a/src/gh_profiler/utils/infra_utils.py
+++ b/src/gh_profiler/utils/infra_utils.py
@@ -1,11 +1,11 @@
 """Utils not really specific to GitHub."""
-
+import os
 import shlex
 import subprocess
 
 
-def run_cmd(cmd):
+def run_cmd(cmd, env=None):
     """Run a subprocess command, return stdout."""
     cmd_parts = shlex.split(cmd)
-    output_obj = subprocess.run(cmd_parts, capture_output=True)
+    output_obj = subprocess.run(cmd_parts, capture_output=True, env=env or os.environ)
     return output_obj.stdout.decode()

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -1,6 +1,7 @@
 """Utils for retrieving user information."""
 
 import json
+import re
 from datetime import datetime as dt
 from datetime import timezone as tz
 from datetime import timedelta
@@ -34,6 +35,10 @@ def get_profile_info():
     """Get all the profile info we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
     profile_info = infra_utils.run_cmd(cmd)
+    # In some cases the GitHub CLI will include ASCII color codes in its output. In order to
+    # br able to parse the JSON properly we need to strip those color codes out.
+    profile_info = re.sub(r'\x1b\[[\d;]*m', '', profile_info)
+    
     pdata.profile_info = json.loads(profile_info)
 
     if "created_at" not in pdata.profile_info:

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -35,12 +35,8 @@ def ensure_gh():
 def get_profile_info():
     """Get all the profile info we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
-    env = {
-        **os.environ,
-        'CLICOLOR_FORCE': '0',
-        'NO_COLOR': '1',
-    }
-    profile_info = infra_utils.run_cmd(cmd, env=env)
+
+    profile_info = infra_utils.run_cmd(cmd)
     
     pdata.profile_info = json.loads(profile_info)
 

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -1,6 +1,7 @@
 """Utils for retrieving user information."""
 
 import json
+import os
 import re
 from datetime import datetime as dt
 from datetime import timezone as tz
@@ -34,10 +35,12 @@ def ensure_gh():
 def get_profile_info():
     """Get all the profile info we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
-    profile_info = infra_utils.run_cmd(cmd)
-    # In some cases the GitHub CLI will include ASCII color codes in its output. In order to
-    # br able to parse the JSON properly we need to strip those color codes out.
-    profile_info = re.sub(r'\x1b\[[\d;]*m', '', profile_info)
+    env = {
+        **os.environ,
+        'CLICOLOR_FORCE': '0',
+        'NO_COLOR': '1',
+    }
+    profile_info = infra_utils.run_cmd(cmd, env=env)
     
     pdata.profile_info = json.loads(profile_info)
 


### PR DESCRIPTION
Resolves #23 

The `gh` output in some cases may include ASCII color coding:

```
\x1b[1;38m{\x1b[m\n\x1b[1;34m"bio"\x1b[m\x1b[1;38m:\x1b[m \x1b[32m"Just a guy writing some code."\x1b[m\x1b[1;38m,\x1b[m\n\x1b[1;34m"blog"\x1b[m\x1b[1;38m:\x1b[m \x1b[32m"https://brassnet.biz"\x1b[m\x1b[1;38m,\x1b[m\n\x1b[1;34m"company"\x1b[m\x1b[1;38m:\x1b[m \x1b[36mnull\x1b[m\x1b[1;38m,\x1b[m\n\x1b[1;34m"created_at"\x1b[m\x1b[1;38m:\x1b[m \x1b[32m"2012-06-01T17:26:04Z"\x1b[m\x1b[1;38m,\x1b[m\n\x1b[1;34m"email"\x1b[m\x1b[1;38m:\x1b[m \x1b[32m"dan@brassnet.biz"\x1b[m\x1b[1;38m,\x1b[m\n\x1b[1;34m"location"\x1b[m\x1b[1;38m:\x1b[m \x1b[36mnull\x1b[m\x1b[1;38m,\x1b[m\n\x1b[1;34m"login"\x1b[m\x1b[1;38m:\x1b[m \x1b[32m"brass75"\x1b[m\x1b[1;38m,\x1b[m\n\x1b[1;34m"name"\x1b[m\x1b[1;38m:\x1b[m \x1b[32m"Dan Shernicoff"\x1b[m\n\x1b[1;38m}\x1b[m\n
```

This change will strip out that encoding.

Local testing:

```sh
user: brass75 [ main] [🐍  3.14.0 (gh-profiler)]
~/src/gh-profiler [🟢 ]$ gh-profiler brass75                                                                           
GitHub user: brass75
  🟢 Account age: 5084 days

  🟢 Profile information:
      name: Dan Shernicoff
      blog: https://brassnet.biz
      email: dan@brassnet.biz
      bio: Just a guy writing some code.
     Empty fields: company, location

  🟢 brass75 has opened fewer than 10 PRs in the last 21 days.

user: brass75 [ main] [🐍  3.14.0 (gh-profiler)]
~/src/gh-profiler [🟢 ]$ gh-profiler ehmatthes                                                                            
GitHub user: ehmatthes
  🟢 Account age: 5061 days

  🟢 Profile information:
      name: Eric Matthes
      blog: https://www.mostlypython.com
      location: western North Carolina
      email: ehmatthes@gmail.com
     Empty fields: company, bio

  🟢 12 of 12 PRs have been merged in the last 21 days.
  🟢 0 of 12 PRs have been closed without merging in the last 21 days.

user: brass75 [ main] [🐍  3.14.0 (gh-profiler)]
~/src/gh-profiler [🟢 ]$ gh-profiler ehmatthe                                                                             
GitHub user 'ehmatthe' not found.
```

I didn't see any testing for `profile_utils.py` so no additional testing was added.