### PR TITLE
Handle github users who haven't opened issues recently

### DIFF
--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -94,7 +94,7 @@ def _issue_activity_summary():
     """Summarize recent public issue activity."""
     ...
     if pdata.new_issue_count == 0:
-        return f"\n    {pdata.usename} has not opened any new issues in the last 21 days.\n"
+        return f"\n    {pdata.username} has not opened any new issues in the last 21 days.\n"
 
     summary = f"  {pdata.flag_overall_issues} {pdata.username} has opened {pdata.new_issue_count} new issues in the last 21 days.\n"
     summary += f"     {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues have been closed as NOT_PLANNED.\n"


### PR DESCRIPTION
Fun tool--thanks! 

This PR fixes an error that occurs when the supplied github user hasn't opened any new issues in the last 21 days.

To reproduce: `uvx gh-profiler bsweger`

```
❯ uvx gh-profiler bsweger
Traceback (most recent call last):
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/gh_profiler/cli.py", line 32, in main
    pr_issue_num = int(target)
ValueError: invalid literal for int() with base 10: 'bsweger'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/bin/gh-profiler", line 12, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/gh_profiler/cli.py", line 34, in main
    gh_profiler.main(target)
    ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/gh_profiler/gh_profiler.py", line 39, in main
    summary_utils.show_summary()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/gh_profiler/utils/summary_utils.py", line 9, in show_summary
    summary = _get_summary()
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/gh_profiler/utils/summary_utils.py", line 28, in _get_summary
    summary += _issue_activity_summary()
               ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/becky/.cache/uv/archive-v0/AmO_wThkal2FHhr54cfW9/lib/python3.13/site-packages/gh_profiler/utils/summary_utils.py", line 97, in _issue_activity_summary
    return f"\n    {pdata.usename} has not opened any new issues in the last 21 days.\n"
                    ^^^^^^^^^^^^^
AttributeError: 'ProfileData' object has no attribute 'usename'. Did you mean: 'username'?
```