### PR TITLE
Improve performance by making fewer gh calls.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 
 .DS_Store
 
+# Used for cProfile output.
+profile.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### 0.3.3
+
+#### External changes
+
+- Increased exception handling, should catch some failed gh calls.
+- Fewer external calls, should run faster by about 1-2 seconds.
+
+#### Internal changes
+
+- Makes one call to get recent PR activity instead of three.
+- Check for authentication at first external gh call, rather than separate call just to check authentication.
+
 ### 0.3.2
 
 #### External changes

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -17,8 +17,6 @@ def ensure_gh():
 
     Check for authentication issues in first external call, rather than making
     a call just for that purpose here.
-
-    DEV: This may need different implementation on Windows or Linux.
     """
     cmd = "gh --version"
     try:
@@ -33,14 +31,7 @@ def get_profile_info():
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
 
     profile_info = infra_utils.run_cmd(cmd)
-
-    # This is the first external call we're making. Check for an authentication
-    # issue here, instead of making a separate call in ensure_gh().
-    if not profile_info.strip():
-        msg = "The GitHub CLI tool (gh) is not authenticated, or the API hung."
-        msg += "\n  If you've already authenticated, try running the gh-profiler command again."
-        msg += "\n  If you're not authenticated, run `gh auth login`."
-        sys.exit(msg)
+    _ensure_authenticated(profile_info)
 
     try:
         pdata.profile_info = json.loads(profile_info)
@@ -103,6 +94,19 @@ def get_issue_activity():
 
 
 # --- Helper functions ---
+
+def _ensure_authenticated(profile_info):
+    """Check that the gh CLI tool has been authenticated.
+    
+    This should be called when the first external gh call is made.
+    Making this check on the output of an actual call is more efficent than 
+    calling `gh api user --jq .login` just to verify authentication.
+    """
+    if not profile_info.strip():
+        msg = "The GitHub CLI tool (gh) is not authenticated, or the API hung."
+        msg += "\n  If you've already authenticated, try running the gh-profiler command again."
+        msg += "\n  If you're not authenticated, run `gh auth login`."
+        sys.exit(msg)
 
 
 def _get_gh_issues_call(username, cutoff):

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -39,7 +39,12 @@ def get_profile_info():
 
     profile_info = infra_utils.run_cmd(cmd)
 
-    pdata.profile_info = json.loads(profile_info)
+    try:
+        pdata.profile_info = json.loads(profile_info)
+    except json.decoder.JSONDecodeError:
+        msg = "Couldn't get GitHub profile info. The gh CLI may have timed out."
+        msg += "\n  You may want to try running the command again."
+        sys.exit(msg)
 
     if "created_at" not in pdata.profile_info:
         sys.exit(f"GitHub user '{pdata.username}' not found.")

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -84,13 +84,7 @@ def get_pr_activity():
     """
 
     search_query = f"author:{pdata.username} is:pull-request created:>={cutoff}"
-
-    cmd = (
-        "gh api graphql "
-        f"-f query='{query}' "
-        f"-F q='{search_query}' "
-        "-F n=100"
-    )
+    cmd = f"gh api graphql -f query='{query}' -F q='{search_query}' -F n=100"
 
     try:
         data = json.loads(infra_utils.run_cmd(cmd))

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -57,6 +57,7 @@ def get_profile_info():
     if pdata.profile_info["created_at"] is None:
         sys.exit(f"GitHub user '{pdata.username}' not found.")
 
+
 def get_pr_activity():
     """Get information about recent PR activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
@@ -78,8 +79,7 @@ def get_pr_activity():
     pdata.opened_count = len(prs)
     pdata.merged_count = sum(pr["mergedAt"] is not None for pr in prs)
     pdata.closed_count = sum(
-        pr["state"] == "CLOSED" and pr["mergedAt"] is None
-        for pr in prs
+        pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs
     )
 
 
@@ -134,6 +134,7 @@ def _get_gh_issues_call(username, cutoff):
     """
 
     return dedent(gh_call).strip()
+
 
 def _get_pr_query():
     """Return the graphql query for recent PR activity."""

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -57,27 +57,57 @@ def get_profile_info():
     if pdata.profile_info["created_at"] is None:
         sys.exit(f"GitHub user '{pdata.username}' not found.")
 
-
 def get_pr_activity():
     """Get information about recent PR activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
-    base_query = f"author:{pdata.username} is:pr created:>={cutoff}"
 
-    opened_cmd = f'gh api "search/issues?q={quote(base_query)}" --jq .total_count'
-    merged_cmd = (
-        f'gh api "search/issues?q={quote(base_query + " is:merged")}" --jq .total_count'
+    query = """
+    query($q: String!, $n: Int!) {
+      search(query: $q, type: ISSUE, first: $n) {
+        issueCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          ... on PullRequest {
+            number
+            state
+            createdAt
+            closedAt
+            mergedAt
+            url
+          }
+        }
+      }
+    }
+    """
+
+    search_query = f"author:{pdata.username} is:pull-request created:>={cutoff}"
+
+    cmd = (
+        "gh api graphql "
+        f"-f query='{query}' "
+        f"-F q='{search_query}' "
+        "-F n=100"
     )
-    closed_cmd = f'gh api "search/issues?q={quote(base_query + " is:closed -is:merged")}" --jq .total_count'
 
-    # DEV: These calls seem to be timing out occasionally.
     try:
-        pdata.opened_count = int(infra_utils.run_cmd(opened_cmd).strip())
-        pdata.merged_count = int(infra_utils.run_cmd(merged_cmd).strip())
-        pdata.closed_count = int(infra_utils.run_cmd(closed_cmd).strip())
-    except ValueError:
+        data = json.loads(infra_utils.run_cmd(cmd))
+    except json.decoder.JSONDecodeError:
         msg = "Couldn't get recent PR activity. The gh CLI may have timed out."
         msg += "\n  You may want to try running the command again."
         sys.exit(msg)
+
+    search = data["data"]["search"]
+    prs = search["nodes"]
+
+    pdata.opened_count = len(prs)
+    pdata.merged_count = sum(pr["mergedAt"] is not None for pr in prs)
+    pdata.closed_count = sum(
+        pr["state"] == "CLOSED" and pr["mergedAt"] is None
+        for pr in prs
+    )
 
 
 def get_issue_activity():

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -85,7 +85,7 @@ def get_issue_activity():
 
     try:
         pdata.issue_activity = json.loads(issue_activity)["data"]["search"]
-    except json.decoder.JSONDecodeError:
+    except (json.decoder.JSONDecodeError, KeyError):
         msg = "Couldn't get recent issue activity. The gh CLI may have timed out."
         msg += "\n  You may want to try running the command again."
         sys.exit(msg)

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -15,8 +15,8 @@ from . import infra_utils
 def ensure_gh():
     """Make sure user has gh installed and is authenticated.
 
-    Performance: The `gh --version` call is entirely local, and takes almost no time.
-    There's no performance benefit to eliminating that call.
+    Check for authentication issues in first external call, rather than making
+    a call just for that purpose here.
 
     DEV: This may need different implementation on Windows or Linux.
     """
@@ -28,19 +28,19 @@ def ensure_gh():
         msg += "\n  https://cli.github.com"
         sys.exit(msg)
 
-    cmd = "gh api user --jq .login"
-    if not infra_utils.run_cmd(cmd).strip():
-        msg = "The GitHub CLI tool (gh) is not authenticated, or the API hung."
-        msg += "\n  If you've already authenticated, try running the gh-profiler command again."
-        msg += "\n  If you're not authenticated, run `gh auth login`."
-        sys.exit(msg)
-
-
 def get_profile_info():
     """Get all the profile info we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
 
     profile_info = infra_utils.run_cmd(cmd)
+
+    # This is the first external call we're making. Check for an authentication
+    # issue here, instead of making a separate call in ensure_gh().
+    if not profile_info.strip():
+        msg = "The GitHub CLI tool (gh) is not authenticated, or the API hung."
+        msg += "\n  If you've already authenticated, try running the gh-profiler command again."
+        msg += "\n  If you're not authenticated, run `gh auth login`."
+        sys.exit(msg)
 
     try:
         pdata.profile_info = json.loads(profile_info)

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -61,30 +61,9 @@ def get_pr_activity():
     """Get information about recent PR activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
 
-    query = """
-    query($q: String!, $n: Int!) {
-      search(query: $q, type: ISSUE, first: $n) {
-        issueCount
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        nodes {
-          ... on PullRequest {
-            number
-            state
-            createdAt
-            closedAt
-            mergedAt
-            url
-          }
-        }
-      }
-    }
-    """
-
+    pr_query = _get_pr_query()
     search_query = f"author:{pdata.username} is:pull-request created:>={cutoff}"
-    cmd = f"gh api graphql -f query='{query}' -F q='{search_query}' -F n=100"
+    cmd = f"gh api graphql -f query='{pr_query}' -F q='{search_query}' -F n=100"
 
     try:
         data = json.loads(infra_utils.run_cmd(cmd))
@@ -155,3 +134,29 @@ def _get_gh_issues_call(username, cutoff):
     """
 
     return dedent(gh_call).strip()
+
+def _get_pr_query():
+    """Return the graphql query for recent PR activity."""
+    pr_query = f"""
+        query($q: String!, $n: Int!) {{
+            search(query: $q, type: ISSUE, first: $n) {{
+                issueCount
+                pageInfo {{
+                hasNextPage
+                endCursor
+                }}
+                nodes {{
+                ... on PullRequest {{
+                    number
+                    state
+                    createdAt
+                    closedAt
+                    mergedAt
+                    url
+                }}
+                }}
+            }}
+            }}
+    """
+
+    return dedent(pr_query).strip()

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -15,6 +15,9 @@ from . import infra_utils
 def ensure_gh():
     """Make sure user has gh installed and is authenticated.
 
+    Performance: The `gh --version` call is entirely local, and takes almost no time.
+    There's no performance benefit to eliminating that call.
+
     DEV: This may need different implementation on Windows or Linux.
     """
     cmd = "gh --version"

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -4,7 +4,6 @@ import json
 from datetime import datetime as dt
 from datetime import timezone as tz
 from datetime import timedelta
-from urllib.parse import quote
 from textwrap import dedent
 import sys
 

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -26,6 +26,7 @@ def ensure_gh():
         msg += "\n  https://cli.github.com"
         sys.exit(msg)
 
+
 def get_profile_info():
     """Get all the profile info we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
@@ -95,11 +96,12 @@ def get_issue_activity():
 
 # --- Helper functions ---
 
+
 def _ensure_authenticated(profile_info):
     """Check that the gh CLI tool has been authenticated.
-    
+
     This should be called when the first external gh call is made.
-    Making this check on the output of an actual call is more efficent than 
+    Making this check on the output of an actual call is more efficent than
     calling `gh api user --jq .login` just to verify authentication.
     """
     if not profile_info.strip():

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -89,11 +89,12 @@ def test_summary_empty_profile(empty_profile_info):
     summary = summary_utils._get_summary()
     assert summary.strip() == reference_summaries.summary_empty_profile
 
+
 def test_no_issue_activity():
     """Test output when there's no recent issue activity."""
     pdata.new_issue_count = 0
     summary = summary_utils._get_summary()
-    
+
     assert "🟢 ehmatthes has not opened any new issues in the last 21 days." in summary
     assert "issues have been closed as NOT_PLANNED." not in summary
     assert "issues were opened with the same title:" not in summary


### PR DESCRIPTION
Get all PR activity in one call, then analyze locally for needed information. Also, no separate check for whether gh is authenticated.