### PR TITLE
Comma separate thousands in account age

### DIFF
--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -28,7 +28,7 @@ def _get_summary():
     summary += _username_line()
 
     # Always include account age.
-    summary += f"  {pdata.flag_age} Account age: {pdata.account_age.days} days\n"
+    summary += f"  {pdata.flag_age} Account age: {pdata.account_age.days:,} days\n"
 
     # Include profiler, PR activity, and issue activity sections.
     summary += _profile_summary()

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -2,7 +2,7 @@
 
 full_summary = """
 GitHub user: ehmatthes
-  🟢 Account age: 5058 days
+  🟢 Account age: 5,058 days
 
   🟢 Profile information:
       name: Eric Matthes
@@ -20,7 +20,7 @@ GitHub user: ehmatthes
 
 summary_empty_profile = """
 GitHub user: ehmatthes
-  🟢 Account age: 5058 days
+  🟢 Account age: 5,058 days
 
   🔴 No profile information has been provided.
 


### PR DESCRIPTION

Instead of:

>  🟢 Account age: 5058 days
 
Show:

>  🟢 Account age: 5,058 days