### PR TITLE
Support a --concise flag, to give a condensed summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### 0.4.0
+
+#### External changes
+
+- Supports `--concise` flag, which generates a more condensed summary that only shows one line for each major section: profile, recent PR activity, and recent issue activity.
+
+#### Internal changes
+---
+
+- Simplified CLI argument parsing.
+
 ### 0.3.5
 
 #### External changes

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ When you've installed the project, you can also run it as a module:
 $ python -m gh_profiler <username>
 ```
 
+Concise output
+---
+
+If you want just the simplest summary, you can pass the `--concise` flag:
+
+```sh
+$ uvx gh-profiler <redacted> --concise
+GitHub user: <redacted>
+🟡 Some concerns found with user's profile.
+🟢 No concerns found with recent PR activity.
+🔴 Significant concerns found with recent issue activity.
+
+For a more detailed report, run `gh-profiler <redacted>`.
+```
+
 Maintaining
 ---
 

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -10,6 +10,7 @@ from .utils.profile_data import profile_data as pdata
 @click.command()
 @click.argument("target")
 @click.version_option(package_name="gh-profiler")
+@click.option("--concise", is_flag=True, help="Show concise output; one flag per category.")
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
 def main(target, redact):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -12,7 +12,7 @@ from .utils.profile_data import profile_data as pdata
 @click.version_option(package_name="gh-profiler")
 @click.option("--concise", is_flag=True, help="Show concise output; one flag per category.")
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
-def main(target, redact):
+def main(target, concise, redact):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
@@ -29,8 +29,8 @@ def main(target, redact):
       ...
     """
     # Parse CLI options.
-    if redact:
-        pdata.redact = True
+    pdata.concise = concise
+    pdata.redact = redact
 
     # If the main argument is an integer, process the PR/issue number.
     # Otherwise, assume it's the username.

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -15,6 +15,8 @@ def process_data():
     _process_pr_activity()
     _process_issue_activity()
 
+    _set_overall_flags()
+
 
 # --- Helper functions ---
 
@@ -127,17 +129,54 @@ def _process_repeated_issues():
     pdata.flag_repeated_issues = flag
 
 
+def _set_overall_flags():
+    """Set the overall flags, based on individual flags.
+    
+    These are used for header lines in the final summary, and for the concise
+    summary as well.
+    """
+    _process_profile_flags()
+    _process_pr_flags()
+    _process_issue_flags()
+
+def _process_profile_flags():
+    """Determine a flag for the overall profile section."""
+    profile_flags = (
+        pdata.flag_age,
+        pdata.flag_profile,
+    )
+
+def _process_pr_flags():
+    """Determine a flag for the overall PR section."""
+    ...
+
 def _process_issue_flags():
     """Determine a flag for the overall issue section."""
     issues_flags = (
         pdata.flag_issues_not_planned,
         pdata.flag_repeated_issues,
     )
+    pdata.flag_overall_issues = _get_overall_flag(issues_flags)
 
-    # Overall flag is red if any flags are red...
-    if flags.red_flag in issues_flags:
-        pdata.flag_overall_issues = flags.red_flag
-    elif flags.yellow_flag in issues_flags:
-        pdata.flag_overall_issues = flags.yellow_flag
-    else:
-        pdata.flag_overall_issues = flags.green_flag
+    # # Overall flag is red if any flags are red...
+    # if flags.red_flag in issues_flags:
+    #     pdata.flag_overall_issues = flags.red_flag
+    # elif flags.yellow_flag in issues_flags:
+    #     pdata.flag_overall_issues = flags.yellow_flag
+    # else:
+    #     pdata.flag_overall_issues = flags.green_flag
+
+def _get_overall_flag(component_flags):
+    """Get an overall flag based on individual flags from a section.
+    
+    Overall flag is red if any component flag is red.
+    Then, yellow if any component flag is yellow.
+    If no red or yellow flags, return green.
+    """
+    if flags.red_flag in component_flags:
+        return flags.red_flag
+    
+    if flags.yellow_flag in component_flags:
+        return flags.yellow_flag
+
+    return flags.green_flag

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -55,6 +55,8 @@ def _process_pr_activity():
     """Evaluate recent PR activity."""
     # Don't need to analyze PR activity if fewer than 10 PRs opened recently.
     if pdata.opened_count < 10:
+        pdata.flag_merged_pr = flags.green_flag
+        pdata.flag_closed_pr = flags.green_flag
         return
 
     ratio_merged = pdata.merged_count / pdata.opened_count
@@ -145,10 +147,16 @@ def _process_profile_flags():
         pdata.flag_age,
         pdata.flag_profile,
     )
+    pdata.flag_overall_profile = _get_overall_flag(profile_flags)
 
 def _process_pr_flags():
     """Determine a flag for the overall PR section."""
-    ...
+    # flag_merged is either None or green. It's never yellow or red.
+    # People can have PRs open for a long time waiting for merges.
+    pr_flags = (
+        pdata.flag_closed_pr,
+    )
+    pdata.flag_overall_pr = _get_overall_flag(pr_flags)
 
 def _process_issue_flags():
     """Determine a flag for the overall issue section."""
@@ -157,14 +165,6 @@ def _process_issue_flags():
         pdata.flag_repeated_issues,
     )
     pdata.flag_overall_issues = _get_overall_flag(issues_flags)
-
-    # # Overall flag is red if any flags are red...
-    # if flags.red_flag in issues_flags:
-    #     pdata.flag_overall_issues = flags.red_flag
-    # elif flags.yellow_flag in issues_flags:
-    #     pdata.flag_overall_issues = flags.yellow_flag
-    # else:
-    #     pdata.flag_overall_issues = flags.green_flag
 
 def _get_overall_flag(component_flags):
     """Get an overall flag based on individual flags from a section.
@@ -175,8 +175,6 @@ def _get_overall_flag(component_flags):
     """
     if flags.red_flag in component_flags:
         return flags.red_flag
-    
     if flags.yellow_flag in component_flags:
         return flags.yellow_flag
-
     return flags.green_flag

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -53,6 +53,9 @@ class ProfileData:
     flag_issues_not_planned: str = ""
     flag_repeated_issues: str = ""
 
+    # Overall flags. Used in header lines in summary, and for --concise output.
+    flag_overall_profile: str = ""
+    flag_overall_pr: str = ""
     flag_overall_issues: str = ""
 
     # --- Behavior fields ---

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -56,8 +56,10 @@ class ProfileData:
     flag_overall_issues: str = ""
 
     # --- Behavior fields ---
+    concise: bool = False
     # Redact is used primarily for live demos, and screenshots.
     redact: bool = False
+
 
 
 profile_data = ProfileData()

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -28,16 +28,27 @@ def _get_concise_summary():
     summary = ""
 
     summary += f"GitHub user: {pdata.username}\n"
+    summary += _get_concise_section(
+        pdata.flag_overall_profile,
+        "user's profile",
+    )
     
-    if pdata.flag_overall_profile == flags.green_flag:
-        summary += f"{flags.green_flag} No concerns found with user's profile."
-    elif pdata.flag_overall_profile == flags.yellow_flag:
-        summary += f"{flags.yellow_flag} Some concerns found with user's profile."
-    elif pdata.flag_overall_profile == flags.red_flag:
-        summary += f"{flags.red_flag} Significant concerns found with user's profile."
+    # if pdata.flag_overall_profile == flags.green_flag:
+    #     summary += f"{flags.green_flag} No concerns found with user's profile."
+    # elif pdata.flag_overall_profile == flags.yellow_flag:
+    #     summary += f"{flags.yellow_flag} Some concerns found with user's profile."
+    # elif pdata.flag_overall_profile == flags.red_flag:
+    #     summary += f"{flags.red_flag} Significant concerns found with user's profile."
 
     return summary
-    
+
+def _get_concise_section(flag, section):
+    if flag == flags.green_flag:
+        return f"{flag} No concerns found with {section}."
+    elif flag == flags.yellow_flag:
+        return f"{flag} Some concerns found with {section}."
+    elif flag == flags.red_flag:
+        return f"{flag} Significant concerns found with {section}."
 
 
 def _get_full_summary():

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -11,13 +11,37 @@ def show_summary():
 
 
 def _get_summary():
-    """Build a summary string.
-
-    This is more testable and flexible than just printing each bit of information.
-    """
+    """Build a summary string."""
     if pdata.redact:
         _redact_info()
 
+    if pdata.concise:
+        return _get_concise_summary()
+    else:
+        return _get_full_summary()
+
+def _get_concise_summary():
+    """Build the shorter, concise summary string.
+    
+    This is one line for each main section: name, profile, pr activity, issue activity.
+    """
+    summary = ""
+
+    summary += f"GitHub user: {pdata.username}\n"
+    
+    if pdata.flag_overall_profile == flags.green_flag:
+        summary += f"{flags.green_flag} No concerns found with user's profile."
+    elif pdata.flag_overall_profile == flags.yellow_flag:
+        summary += f"{flags.yellow_flag} Some concerns found with user's profile."
+    elif pdata.flag_overall_profile == flags.red_flag:
+        summary += f"{flags.red_flag} Significant concerns found with user's profile."
+
+    return summary
+    
+
+
+def _get_full_summary():
+    """Build the full, detailed summary string."""
     summary = ""
 
     # If target is a PR or issue, add title.

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -28,27 +28,31 @@ def _get_concise_summary():
     summary = ""
 
     summary += f"GitHub user: {pdata.username}\n"
+
     summary += _get_concise_section(
         pdata.flag_overall_profile,
         "user's profile",
     )
-    
-    # if pdata.flag_overall_profile == flags.green_flag:
-    #     summary += f"{flags.green_flag} No concerns found with user's profile."
-    # elif pdata.flag_overall_profile == flags.yellow_flag:
-    #     summary += f"{flags.yellow_flag} Some concerns found with user's profile."
-    # elif pdata.flag_overall_profile == flags.red_flag:
-    #     summary += f"{flags.red_flag} Significant concerns found with user's profile."
+
+    summary += _get_concise_section(
+        pdata.flag_overall_pr,
+        "recent PR activity",
+    )
+
+    summary += _get_concise_section(
+        pdata.flag_overall_issues,
+        "recent issue activity",
+    )
 
     return summary
 
 def _get_concise_section(flag, section):
     if flag == flags.green_flag:
-        return f"{flag} No concerns found with {section}."
+        return f"{flag} No concerns found with {section}.\n"
     elif flag == flags.yellow_flag:
-        return f"{flag} Some concerns found with {section}."
+        return f"{flag} Some concerns found with {section}.\n"
     elif flag == flags.red_flag:
-        return f"{flag} Significant concerns found with {section}."
+        return f"{flag} Significant concerns found with {section}.\n"
 
 
 def _get_full_summary():

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -44,7 +44,7 @@ def _get_concise_summary():
         "recent issue activity",
     )
 
-    summary += f"For a more detailed report, run `gh-profiler {pdata.username}` without the --concise flag."
+    summary += f"\nFor a more detailed report, run `gh-profiler {pdata.username}`."
 
     return summary
 

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -44,6 +44,8 @@ def _get_concise_summary():
         "recent issue activity",
     )
 
+    summary += f"For a more detailed report, run `gh-profiler {pdata.username}` without the --concise flag."
+
     return summary
 
 def _get_concise_section(flag, section):

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -51,6 +51,8 @@ def filled_pdata():
     pdata.flag_repeated_issues = flags.green_flag
 
     # Call function to process this?
+    pdata.flag_overall_profile = flags.green_flag
+    pdata.flag_overall_pr = flags.green_flag
     pdata.flag_overall_issues = flags.green_flag
 
 

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -39,3 +39,11 @@ def test_redact():
 
     assert "ehmatthes" not in summary
     assert summary.count("<redacted") == 7
+
+def test_concise():
+    """Test output with pdata.concise set to True."""
+    pdata.concise = True
+    summary = summary_utils._get_summary()
+
+    assert "No concerns found with user's profile." in summary
+    assert "Account age:" not in summary


### PR DESCRIPTION
This is motivated by the desire to write a GH action that dumps the output of gh-profiler as a comment into every new issue and PR. The full output is too long for that.

Sample output:

```sh
$ uvx gh-profiler <redacted> --concise
GitHub user: <redacted>
🟡 Some concerns found with user's profile.
🟢 No concerns found with recent PR activity.
🔴 Significant concerns found with recent issue activity.

For a more detailed report, run `gh-profiler <redacted>`.
```