### PR TITLE
Fetch data efficiently, and then parse it in a separate step.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
-### Unreleased
+### 0.6.0
 
 #### External changes
 
-- NA
+- gh-profiler runs meaningfully faster, by parallelizing the calls that fetch external data.
 
 #### Internal changes
 
 - Basic e2e tests for full and --concise runs. E2e tests are flaky because they make actual gh API calls. E2e tests must be run explicitly, ie `uv run pytest tests/e2e_tests -k full`.
+- Uses `ThreadPoolExecutor` to parallelize the fetching calls. We shouldn't add many more calls, but this should mean a few more quick calls are essentially free. The call to fetch issue activity is the slowest, so any fetch significantly faster than that should add not add to execution time in any meaningful way.
+- Supports `--benchmark-fetch`, which lets us easily benchmark just the fetching block.
 
 ### 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ These initial releases have usable behavior, but may have some rough edges for s
 
 #### Internal changes
 
-- NA
+- Basic e2e tests for full and --concise runs. E2e tests are flaky because they make actual gh API calls. E2e tests must be run explicitly, ie `uv run pytest tests/e2e_tests -k full`.
 
 ### 0.5.1
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,17 @@ Author: <redacted>
 Running tests
 ---
 
+Run all tests except end-to-end tests:
+
 ```sh
 $ uv run pytest
+```
+
+End-to-end tests are slower, and flakier because they make actual API calls. It's best to run a specific e2e test:
+
+```sh
+$ uv run pytest tests/e2e_tests -k full
+$ uv run pytest tests/e2e_tests -k concise
 ```
 
 Profiling

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+"""Root conftest.py"""
+
+# Don't collect e2e tests; only run when specified over CLI.
+collect_ignore = ["tests/e2e_tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,5 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "pytest-xdist>=3.8.0",
 ]

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -19,7 +19,8 @@ from .utils.profile_data import profile_data as pdata
     help="Generate a workflow that will automatically run `gh-profiler --concise` for every new PR and issue.",
 )
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
-def main(target, concise, generate_workflow, redact):
+@click.option("--benchmark-fetch", is_flag=True, help="Benchmark the code that fetches external data.")
+def main(target, concise, generate_workflow, redact, benchmark_fetch):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
@@ -35,11 +36,12 @@ def main(target, concise, generate_workflow, redact):
     $ python -m gh_profiler ehmatthes
       ...
     """
-    _validate_command(target, concise, generate_workflow, redact)
+    _validate_command(target, concise, generate_workflow, redact, benchmark_fetch)
 
     # Parse CLI options.
     pdata.concise = concise
     pdata.redact = redact
+    pdata.benchmark_fetch = benchmark_fetch
     pdata.generate_workflow = generate_workflow
 
     # If --generate-workflow was passed, go straight to that work.
@@ -60,7 +62,7 @@ def main(target, concise, generate_workflow, redact):
         cli_utils.process_pr_issue_num(pr_issue_num)
         gh_profiler.main()
 
-def _validate_command(target, concise, generate_workflow, redact):
+def _validate_command(target, concise, generate_workflow, redact, benchmark_fetch):
     """Validate arguments that were passed in the CLI call."""
 
     # If target is not passed, --generate-workflow must be passed.

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -65,6 +65,9 @@ class ProfileData:
     # Redact is used primarily for live demos, and screenshots.
     redact: bool = False
 
+    # Benchmark the code that fetches external data.
+    benchmark_fetch: bool = False
+
     generate_workflow: bool = False
 
 

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -39,11 +39,12 @@ def get_data():
     # Fetch data. This can all be done in parallel.
     socials_str = _fetch_socials()
     pr_activity_str = _fetch_pr_activity()
-    _get_issue_activity()
+    issue_activity_str = _fetch_issue_activity()
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_socials(socials_str)
     _parse_pr_activity(pr_activity_str)
+    _parse_issue_activity(issue_activity_str)
 
 
 # --- Helper functions ---
@@ -71,7 +72,7 @@ def _get_profile_dict():
         sys.exit(f"GitHub user '{pdata.username}' not found.")
 
 def _fetch_socials():
-    """Get social media accounts from user's profile.
+    """Fetch social media accounts from user's profile.
     
     Social media accounts from profiles are a separate endpoint, so I believe
     they require an additional API call.
@@ -90,7 +91,7 @@ def _parse_socials(socials_str):
 
 
 def _fetch_pr_activity():
-    """Get information about recent PR activity."""
+    """Fetch information about recent PR activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
 
     pr_query = _get_pr_query()
@@ -119,19 +120,16 @@ def _parse_pr_activity(pr_activity_str):
     )
 
 
-def _get_issue_activity():
-    """Get target user's recent public issue activity."""
+def _fetch_issue_activity():
+    """Fetch target user's recent public issue activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
     gh_call = _get_gh_issues_call(pdata.username, cutoff)
-    try:
-        issue_activity = infra_utils.run_cmd(gh_call)
-    except ValueError:
-        msg = "Couldn't get recent issue activity. The gh CLI may have timed out."
-        msg += "\n  You may want to try running the command again."
-        sys.exit(msg)
+    return infra_utils.run_cmd(gh_call)
 
+def _parse_issue_activity(issue_activity_str):
+    """Parse data returned by _fetch_issue_activity()."""
     try:
-        pdata.issue_activity = json.loads(issue_activity)["data"]["search"]
+        pdata.issue_activity = json.loads(issue_activity_str)["data"]["search"]
     except (json.decoder.JSONDecodeError, KeyError):
         msg = "Couldn't get recent issue activity. The gh CLI may have timed out."
         msg += "\n  You may want to try running the command again."

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -36,10 +36,17 @@ def get_data():
     # to happen before all others.
     _get_profile_dict()
 
+    from time import perf_counter
+
     # Fetch data. This can all be done in parallel.
+    ts_before = perf_counter()
+
     socials_str = _fetch_socials()
     pr_activity_str = _fetch_pr_activity()
     issue_activity_str = _fetch_issue_activity()
+
+    ts_after = perf_counter()
+    print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_socials(socials_str)

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -27,11 +27,24 @@ def ensure_gh():
 
 
 def get_data():
-    """Get all data we'll need from GitHub."""
+    """Get all data we'll need from GitHub.
+    
+    Fetch all data we'll need, then parse it into the data structures that
+    can be analyzed and processed.
+    """
+    _fetch_data()
+    _parse_data()
+
+def _fetch_data():
+    """Fetch all data from GitHub. Don't parse any of it."""
     _get_profile_dict()
     _get_socials()
     _get_pr_activity()
     _get_issue_activity()
+
+def _parse_data():
+    """Parse the data that was fetched."""
+    ...
 
 
 # --- Helper functions ---

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -42,11 +42,13 @@ def _fetch_data():
     _get_profile_dict()
 
     socials_str = _fetch_socials()
-    _get_pr_activity()
+    pr_activity_str = _fetch_pr_activity()
+    # _get_pr_activity()
     _get_issue_activity()
 
     # Parse data.
     _parse_socials(socials_str)
+    _parse_pr_activity(pr_activity_str)
 
 # def _parse_data():
 #     """Parse the data that was fetched."""
@@ -98,7 +100,7 @@ def _parse_socials(socials_str):
         sys.exit(msg)
 
 
-def _get_pr_activity():
+def _fetch_pr_activity():
     """Get information about recent PR activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
 
@@ -107,9 +109,12 @@ def _get_pr_activity():
         f"author:{pdata.username} is:pull-request is:public created:>={cutoff}"
     )
     cmd = f"gh api graphql -f query='{pr_query}' -F q='{search_query}' -F n=100"
+    return infra_utils.run_cmd(cmd)
 
+def _parse_pr_activity(pr_activity_str):
+    """Parse the data returned by _fetch_pr_activity()."""
     try:
-        data = json.loads(infra_utils.run_cmd(cmd))
+        data = json.loads(pr_activity_str)
     except json.decoder.JSONDecodeError:
         msg = "Couldn't get recent PR activity. The gh CLI may have timed out."
         msg += "\n  You may want to try running the command again."

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -2,10 +2,12 @@
 
 import json
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime as dt
 from datetime import timedelta
 from datetime import timezone as tz
 from textwrap import dedent
+from time import perf_counter
 
 from . import infra_utils
 from .profile_data import profile_data as pdata
@@ -36,12 +38,10 @@ def get_data():
     # to happen before all others.
     _get_profile_dict()
 
-    from time import perf_counter
-    from concurrent.futures import ThreadPoolExecutor
-
-    # Fetch data. This can all be done in parallel.
+    # Fetch data. This can all be done in parallel. The benchmarking is here
+    # because this is the slowest part of the program, and it's helpful at
+    # times to benchmark just this block of code.
     ts_before = perf_counter()
-
     with ThreadPoolExecutor() as executor:
         socials_future = executor.submit(_fetch_socials)
         pr_activity_future = executor.submit(_fetch_pr_activity)
@@ -52,7 +52,8 @@ def get_data():
         issue_activity_str = issue_activity_future.result()
 
     ts_after = perf_counter()
-    print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
+    if pdata.benchmark_fetch:
+        print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_socials(socials_str)

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -32,32 +32,21 @@ def get_data():
     Fetch all data we'll need, then parse it into the data structures that
     can be analyzed and processed.
     """
-    _fetch_data()
-    # _parse_data()
-
-def _fetch_data():
-    """Fetch all data from GitHub. Don't parse any of it."""
     # This is the first call, and it checks if the user exists. This call needs
     # to happen before all others.
     _get_profile_dict()
 
+    # Fetch data. This can all be done in parallel.
     socials_str = _fetch_socials()
     pr_activity_str = _fetch_pr_activity()
-    # _get_pr_activity()
     _get_issue_activity()
 
-    # Parse data.
+    # Parse data. This should only happen after all data has been fetched.
     _parse_socials(socials_str)
     _parse_pr_activity(pr_activity_str)
 
-# def _parse_data():
-#     """Parse the data that was fetched."""
-#     _parse_socials()
-#     ...
-
 
 # --- Helper functions ---
-
 
 def _get_profile_dict():
     """Get all the profile information we'll need."""

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -37,13 +37,19 @@ def get_data():
     _get_profile_dict()
 
     from time import perf_counter
+    from concurrent.futures import ThreadPoolExecutor
 
     # Fetch data. This can all be done in parallel.
     ts_before = perf_counter()
 
-    socials_str = _fetch_socials()
-    pr_activity_str = _fetch_pr_activity()
-    issue_activity_str = _fetch_issue_activity()
+    with ThreadPoolExecutor() as executor:
+        socials_future = executor.submit(_fetch_socials)
+        pr_activity_future = executor.submit(_fetch_pr_activity)
+        issue_activity_future = executor.submit(_fetch_issue_activity)
+
+        socials_str = socials_future.result()
+        pr_activity_str = pr_activity_future.result()
+        issue_activity_str = issue_activity_future.result()
 
     ts_after = perf_counter()
     print(f"Fetch data: {ts_after - ts_before:.2f} seconds")

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -33,18 +33,25 @@ def get_data():
     can be analyzed and processed.
     """
     _fetch_data()
-    _parse_data()
+    # _parse_data()
 
 def _fetch_data():
     """Fetch all data from GitHub. Don't parse any of it."""
+    # This is the first call, and it checks if the user exists. This call needs
+    # to happen before all others.
     _get_profile_dict()
-    _get_socials()
+
+    socials_str = _fetch_socials()
     _get_pr_activity()
     _get_issue_activity()
 
-def _parse_data():
-    """Parse the data that was fetched."""
-    ...
+    # Parse data.
+    _parse_socials(socials_str)
+
+# def _parse_data():
+#     """Parse the data that was fetched."""
+#     _parse_socials()
+#     ...
 
 
 # --- Helper functions ---
@@ -72,14 +79,17 @@ def _get_profile_dict():
     if pdata.profile_dict["created_at"] is None:
         sys.exit(f"GitHub user '{pdata.username}' not found.")
 
-def _get_socials():
+def _fetch_socials():
     """Get social media accounts from user's profile.
     
     Social media accounts from profiles are a separate endpoint, so I believe
     they require an additional API call.
     """
     cmd = f"gh api users/{pdata.username}/social_accounts"
-    socials_str = infra_utils.run_cmd(cmd)
+    return infra_utils.run_cmd(cmd)
+
+def _parse_socials(socials_str):
+    """Parse the data string returned from _fetch_socials()."""
     try:
         pdata.socials = json.loads(socials_str)
     except json.decoder.JSONDecodeError:

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -1,0 +1,27 @@
+"""Test real-world gh-profiler calls.
+
+Makes an actual gh-profiler call. Currently calls against my own user account
+(ehmatthes). It would be good to find another target, but I'm not sure what
+to use.
+"""
+
+from gh_profiler.utils import infra_utils
+
+
+def test_full_run():
+    """Test a standard run of gh-profiler."""
+    cmd = "uv run gh-profiler ehmatthes"
+    output = infra_utils.run_cmd(cmd)
+
+    # Make assertions about stable parts of output, not entire output string.
+    # DEV: Find some assertions to make about PRs and issues?
+    expected_strings = (
+        "GitHub user: ehmatthes",
+        "🟢 Profile information:",
+        "name: Eric Matthes",
+        "mastodon: https://fosstodon.org/@ehmatthes",
+        "Empty fields: company, bio",
+    )
+
+    for expected_string in expected_strings:
+        assert expected_string in output

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -15,6 +15,10 @@ def test_full_run():
     cmd = "uv run gh-profiler ehmatthes"
     output = infra_utils.run_cmd(cmd)
 
+    if output == "":
+        msg = "Output was empty, which may indicate a gh timeout rather than a problem with the code."
+        pytest.fail(msg)
+
     # Make assertions about stable parts of output, not entire output string.
     # DEV: Find some assertions to make about PRs and issues?
     expected_strings = (

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -5,6 +5,8 @@ Makes an actual gh-profiler call. Currently calls against my own user account
 to use.
 """
 
+import pytest
+
 from gh_profiler.utils import infra_utils
 
 
@@ -21,6 +23,28 @@ def test_full_run():
         "name: Eric Matthes",
         "mastodon: https://fosstodon.org/@ehmatthes",
         "Empty fields: company, bio",
+    )
+
+    for expected_string in expected_strings:
+        assert expected_string in output
+
+def test_concise_run():
+    """Test a --concise run of gh-profiler."""
+    cmd = "uv run gh-profiler ehmatthes --concise"
+    output = infra_utils.run_cmd(cmd)
+
+    if output == "":
+        msg = "Output was empty, which may indicate a gh timeout rather than a problem with the code."
+        pytest.fail(msg)
+
+    # Make assertions about stable parts of output, not entire output string.
+    # DEV: Find some assertions to make about PRs and issues?
+    expected_strings = (
+        "GitHub user: ehmatthes",
+        "🟢 No concerns found with user's profile.",
+        "🟢 No concerns found with recent PR activity.",
+        "🟢 No concerns found with recent issue activity.",
+        "For a more detailed report, run `gh-profiler ehmatthes`.",
     )
 
     for expected_string in expected_strings:

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "gh-profiler"
 version = "0.5.1"
 source = { editable = "." }
@@ -46,13 +55,17 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
 requires-dist = [{ name = "click", specifier = ">=8.3.3" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -106,6 +119,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Originally, data was fetched and parsed sequentially for each area of behavior that was being examined. Now that the basic usage has been established, it's better to fetch all external data in one step and then parse it in a separate step. That allows the fetching calls to be optimized.

Fetches are parallelized with `ThreadPoolExecutor`. This has a meaningful impact on performance (see #67), and has an even more significant longer term benefit. From this point forward, any additional fetches that are faster than the slowest current fetch (typically for issue activity) are essentially free. They'll finish before the fetch for issue activity, which means they shouldn't add to the overall execution time at all. That's a really useful improvement.

A new flag `--benchmark-fetch` is included, which lets you easily benchmark the fetching calls. This is helpful to check if the above claim remains valid.

This also includes a basic e2e test. You need to call it explicitly, as noted in the testing section of the readme.