### PR TITLE
Test on GitHub Actions via tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "pypy3.11"
+          - "3.15"
+          - "3.14"
+          - "3.13"
+          - "3.12"
+          - "3.11"
+          - "3.10"
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Tox tests
+        run: |
+          uvx --python ${{ matrix.python-version }} --with tox-uv tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+requires =
+    tox>=4.32
+env_list =
+    pypy3
+    py{310-315}
+
+[testenv]
+pass_env =
+    FORCE_COLOR
+commands =
+    {envpython} -m pytest {posargs}
+dependency_groups =
+    dev


### PR DESCRIPTION
This runs the tests on GitHub Actions, to make sure no incoming PRs break the tests.

It also uses tox, to make it easy to test multiple versions locally.

For example:
```sh
tox                 # Test all versions in sequence
tox -e py314        # Test just 3.14
tox -e py310,py314  # Test 3.10 and then 3.14 in sequence
tox -p auto         # Test all in parallel
```

If you don't have a given Python version installed locally, it'll be skipped.
