### PR TITLE
Humanize the account age

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.3.3",
+    "humanize",
 ]
 
 [project.scripts]

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -1,5 +1,6 @@
 """Utils for summarizing findings."""
 
+import humanize
 from .profile_data import profile_data as pdata
 from . import flags
 
@@ -69,7 +70,8 @@ def _get_full_summary():
     summary += _username_line()
 
     # Always include account age.
-    summary += f"  {pdata.flag_age} Account age: {pdata.account_age.days:,} days\n"
+    age = humanize.naturaldelta(pdata.account_age)
+    summary += f"  {pdata.flag_age} Account age: {age}\n"
 
     # Include profiler, PR activity, and issue activity sections.
     summary += _profile_summary()

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -2,7 +2,7 @@
 
 full_summary = """
 GitHub user: ehmatthes
-  🟢 Account age: 5,058 days
+  🟢 Account age: 13 years
 
   🟢 Profile information:
       name: Eric Matthes
@@ -20,7 +20,7 @@ GitHub user: ehmatthes
 
 summary_empty_profile = """
 GitHub user: ehmatthes
-  🟢 Account age: 5,058 days
+  🟢 Account age: 13 years
 
   🔴 No profile information has been provided.
 


### PR DESCRIPTION
# Before

```console
❯ uvx gh-profiler ehmatthes
GitHub user: ehmatthes
  🟢 Account age: 5,079 days

❯ uvx gh-profiler dwvshell
GitHub user: dwvshell
  🟢 Account age: 1,899 days

❯ uvx gh-profiler dropyt-cy
GitHub user: dropyt-cy
  🟡 Account age: 344 days

```

# After

```console
❯ gh-profiler ehmatthes
GitHub user: ehmatthes
  🟢 Account age: 13 years

❯ gh-profiler dwvshell
GitHub user: dwvshell
  🟢 Account age: 5 years

❯ gh-profiler dropyt-cy
GitHub user: dropyt-cy
  🟡 Account age: 11 months
```
