### PR TITLE
Make output messages more terse, less verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Profiling
 $ uv run python -m cProfile -s cumtime -m gh_profiler ehmatthes > profile.txt
 ```
 
+Style notes
+---
+
+- When composing output messages, prefer terse messages over verbose messages:
+    - "0 issues closed as NOT_PLANNED." over "0 issues have been closed as NOT_PLANNED."
+
 Benchmarking
 ---
 

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -130,7 +130,7 @@ def _username_line():
 def _profile_summary():
     """Summarize information from the user's profile dict."""
     if pdata.flag_profile == flags.red_flag:
-        return f"\n  {pdata.flag_profile} No profile information has been provided.\n"
+        return f"\n  {pdata.flag_profile} No profile information provided.\n"
 
     # Only show lines for fields that have information.
     # Collect empty fields for last line.
@@ -174,15 +174,15 @@ def _bio_summary(bio):
 def _pr_activity_summary():
     """Summarize recent PR activity."""
     if pdata.opened_count < 10:
-        return f"  {flags.green_flag} {pdata.username} has opened fewer than 10 PRs in the last 21 days.\n"
+        return f"  {flags.green_flag} {pdata.username} opened fewer than 10 PRs in the last 21 days.\n"
 
     summary = ""
     # Only show merged if it's a good sign.
     if pdata.flag_merged_pr == flags.green_flag:
-        summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs have been merged in the last 21 days.\n"
+        summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs merged in the last 21 days.\n"
 
     # Include number closed for everyone.
-    summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs have been closed without merging in the last 21 days.\n"
+    summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs closed without merging in the last 21 days.\n"
 
     return summary
 
@@ -190,16 +190,16 @@ def _pr_activity_summary():
 def _issue_activity_summary():
     """Summarize recent public issue activity."""
     if pdata.new_issue_count == 0:
-        return f"  {flags.green_flag} {pdata.username} has not opened any new issues in the last 21 days.\n"
+        return f"  {flags.green_flag} {pdata.username} opened no new issues in the last 21 days.\n"
 
-    summary = f"  {pdata.flag_overall_issues} {pdata.username} has opened {pdata.new_issue_count} new issues in the last 21 days.\n"
-    summary += f"     {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues have been closed as NOT_PLANNED.\n"
+    summary = f"  {pdata.flag_overall_issues} {pdata.username} opened {pdata.new_issue_count} new issues in the last 21 days.\n"
+    summary += f"     {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues closed as NOT_PLANNED.\n"
 
     # Repeated issues:
     if pdata.total_repeats == 0:
-        summary += f"     {pdata.flag_repeated_issues} {pdata.total_repeats} issues were opened with the same title.\n"
+        summary += f"     {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title.\n"
     else:
-        summary += f"     {pdata.flag_repeated_issues} {pdata.total_repeats} issues were opened with the same title:\n"
+        summary += f"     {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title:\n"
     for title, count in pdata.repeated_issue_titles.items():
         summary += f"        {title} ({count})\n"
 

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,4 +1,9 @@
 # Run unit tests, and e2e tests.
+# 
+# As of 5/23/26, e2e tests are taking just about a second to run.
+# If they're taking much longer than a few seconds, it's probably worth
+# cancelling the run and run again.
+
 uv run pytest
 uv run pytest tests/e2e_tests -k full
 uv run pytest tests/e2e_tests -k concise

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -11,22 +11,22 @@ GitHub user: ehmatthes
       email: ehmatthes@gmail.com
      Empty fields: company, bio
 
-  🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
+  🟢 ehmatthes opened fewer than 10 PRs in the last 21 days.
 
-  🟢 ehmatthes has opened 7 new issues in the last 21 days.
-     🟢 0 issues have been closed as NOT_PLANNED.
-     🟢 0 issues were opened with the same title.
+  🟢 ehmatthes opened 7 new issues in the last 21 days.
+     🟢 0 issues closed as NOT_PLANNED.
+     🟢 0 issues opened with the same title.
 """.strip()
 
 summary_empty_profile = """
 GitHub user: ehmatthes
   🟢 Account age: 13 years
 
-  🔴 No profile information has been provided.
+  🔴 No profile information provided.
 
-  🟢 ehmatthes has opened fewer than 10 PRs in the last 21 days.
+  🟢 ehmatthes opened fewer than 10 PRs in the last 21 days.
 
-  🟢 ehmatthes has opened 7 new issues in the last 21 days.
-     🟢 0 issues have been closed as NOT_PLANNED.
-     🟢 0 issues were opened with the same title.
+  🟢 ehmatthes opened 7 new issues in the last 21 days.
+     🟢 0 issues closed as NOT_PLANNED.
+     🟢 0 issues opened with the same title.
 """.strip()

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -27,9 +27,9 @@ def test_no_issue_activity():
     pdata.new_issue_count = 0
     summary = summary_utils._get_summary()
 
-    assert "🟢 ehmatthes has not opened any new issues in the last 21 days." in summary
-    assert "issues have been closed as NOT_PLANNED." not in summary
-    assert "issues were opened with the same title:" not in summary
+    assert "🟢 ehmatthes opened no new issues in the last 21 days." in summary
+    assert "issues closed as NOT_PLANNED." not in summary
+    assert "issues opened with the same title:" not in summary
 
 
 def test_redact():


### PR DESCRIPTION
When I read these messages repeatedly, they get a bit verbose. It's not a critical issue, but as more output is included in full runs, and with the possibility of a `--deep` flag to capture many of the patterns people have highlighted, a preference for more terse output is probably better for now.