### PR TITLE
Check auth status explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,23 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
-### Unreleased
+### 0.6.1
 
 #### External changes
 
 - Start documenting talks and discussions of this project in README.
+- Much clearer output when the user's gh CLI tool is not authenticated.
 
 #### Internal changes
 
 - Run tests in CI via tox.
 - Small helper script `test_all.sh` to run unit tests, then all e2e tests.
 - Benchmarking script to ensure consistent performance over time.
+    - Benchmarking script has a 5-second cutoff for API calls that seem to hang.
+- Check the output of `gh auth status` explicitly.
+    - This is done in a batched mode, so it does not impact performance.
+    - The call to fetch the target user's profile dict is batched now as well.
+    - Performance is improved by about 0.25 seconds against my own profile, close to 0.10 seconds on users with more activity.
 
 ### 0.6.0
 

--- a/developer_resources/benchmark.py
+++ b/developer_resources/benchmark.py
@@ -30,20 +30,23 @@ try:
 except IndexError:
     target = "ehmatthes"
 
+# Set up the gh-profiler command.
 cmd = f"uv run gh-profiler {target}"
 cmd_parts = shlex.split(cmd)
 
+# Most calls where gh doesn't hang are taking less than 5 seconds. Some calls
+# for highly active users may take longer.
+cutoff = 5
 run_times = []
 while len(run_times) < 5:
+    # Call gh-profiler. Don't wait on apparently hung calls.
     ts_start = perf_counter()
-
-    # DEV: Wrap this so if it takes longer than 5s call it a fail.
-    output_obj = subprocess.run(cmd_parts, capture_output=True)
-
+    output_obj = subprocess.run(cmd_parts, timeout=cutoff, capture_output=True)
     ts_end = perf_counter()
-    run_time = round((ts_end - ts_start), 2)
 
-    if run_time < 5:
+    # Keep the run if it was faster than the cutoff time.
+    run_time = round((ts_end - ts_start), 2)
+    if run_time < cutoff:
         run_times.append(run_time)
         print(f"Successful run: {run_time} sec")
     else:
@@ -52,6 +55,6 @@ while len(run_times) < 5:
 # Report results.
 summary = f"\nMinimum time: {min(run_times)} sec"
 summary += f"\nMedian time:  {statistics.median(run_times)} sec"
-summary += f"\nAll times:    {", ".join([str(rt) for rt in run_times])}"
+summary += f"\nAll times:    {', '.join([str(rt) for rt in run_times])}"
 
 print(summary)

--- a/developer_resources/benchmark.py
+++ b/developer_resources/benchmark.py
@@ -37,6 +37,7 @@ run_times = []
 while len(run_times) < 5:
     ts_start = perf_counter()
 
+    # DEV: Wrap this so if it takes longer than 5s call it a fail.
     output_obj = subprocess.run(cmd_parts, capture_output=True)
 
     ts_end = perf_counter()
@@ -49,8 +50,8 @@ while len(run_times) < 5:
         print(f"Failed run: {run_time} sec")
 
 # Report results.
-summary = f"\nMedian time: {statistics.median(run_times)} sec"
-summary += f"\nMinimum time: {min(run_times)} sec"
-summary += f"\nAll times: {run_times}"
+summary = f"\nMinimum time: {min(run_times)} sec"
+summary += f"\nMedian time:  {statistics.median(run_times)} sec"
+summary += f"\nAll times:    {", ".join([str(rt) for rt in run_times])}"
 
 print(summary)

--- a/developer_resources/benchmark.py
+++ b/developer_resources/benchmark.py
@@ -41,16 +41,18 @@ run_times = []
 while len(run_times) < 5:
     # Call gh-profiler. Don't wait on apparently hung calls.
     ts_start = perf_counter()
-    output_obj = subprocess.run(cmd_parts, timeout=cutoff, capture_output=True)
+    try:
+        output_obj = subprocess.run(cmd_parts, timeout=cutoff, capture_output=True)
+    except subprocess.TimeoutExpired:
+        print("Failed run, timed out.")
+        continue
+        
+    # The run was faster than the cutoff time, so keep it.
     ts_end = perf_counter()
-
-    # Keep the run if it was faster than the cutoff time.
     run_time = round((ts_end - ts_start), 2)
-    if run_time < cutoff:
-        run_times.append(run_time)
-        print(f"Successful run: {run_time} sec")
-    else:
-        print(f"Failed run: {run_time} sec")
+    run_times.append(run_time)
+    print(f"Successful run: {run_time} sec")
+
 
 # Report results.
 summary = f"\nMinimum time: {min(run_times)} sec"

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -44,11 +44,13 @@ def get_data():
     ts_before = perf_counter()
     with ThreadPoolExecutor() as executor:
         status_future = executor.submit(_fetch_status)
+        profile_dict_future = executor.submit(_fetch_profile_dict)
         socials_future = executor.submit(_fetch_socials)
         pr_activity_future = executor.submit(_fetch_pr_activity)
         issue_activity_future = executor.submit(_fetch_issue_activity)
 
         status_str = status_future.result()
+        profile_dict_str = profile_dict_future.result()
         socials_str = socials_future.result()
         pr_activity_str = pr_activity_future.result()
         issue_activity_str = issue_activity_future.result()
@@ -59,6 +61,7 @@ def get_data():
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_status(status_str)
+    _parse_profile_dict(profile_dict_str)
     _parse_socials(socials_str)
     _parse_pr_activity(pr_activity_str)
     _parse_issue_activity(issue_activity_str)
@@ -67,7 +70,7 @@ def get_data():
 # --- Helper functions ---
 
 def _fetch_status():
-    """Find out whether gh-profiler user is authenticated."""
+    """Fetch output of `gh auth status`."""
     cmd = "gh auth status"
     return infra_utils.run_cmd(cmd)
 
@@ -85,13 +88,13 @@ def _parse_status(status_str):
         msg += "\nRun `gh auth login` to authenticate."
         sys.exit(msg)
 
-def _get_profile_dict():
-    """Get all the profile information we'll need."""
+def _fetch_profile_dict():
+    """Fetch the profile information we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
+    return infra_utils.run_cmd(cmd)
 
-    profile_dict_str = infra_utils.run_cmd(cmd)
-    _ensure_authenticated(profile_dict_str)
-
+def _parse_profile_dict(profile_dict_str):
+    """Parse the profile information that was fetched."""
     try:
         pdata.profile_dict = json.loads(profile_dict_str)
     except json.decoder.JSONDecodeError:
@@ -169,20 +172,6 @@ def _parse_issue_activity(issue_activity_str):
     except (json.decoder.JSONDecodeError, KeyError):
         msg = "Couldn't get recent issue activity. The gh CLI may have timed out."
         msg += "\n  You may want to try running the command again."
-        sys.exit(msg)
-
-
-def _ensure_authenticated(profile_dict_str):
-    """Check that the gh CLI tool has been authenticated.
-
-    This should be called when the first external gh call is made.
-    Making this check on the output of an actual call is more efficent than
-    calling `gh api user --jq .login` just to verify authentication.
-    """
-    if not profile_dict_str.strip():
-        msg = "The GitHub CLI tool (gh) is not authenticated, or the API hung."
-        msg += "\n  If you've already authenticated, try running the gh-profiler command again."
-        msg += "\n  If you're not authenticated, run `gh auth login`."
         sys.exit(msg)
 
 

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -36,7 +36,7 @@ def get_data():
     """
     # This is the first call, and it checks if the user exists. This call needs
     # to happen before all others.
-    _get_profile_dict()
+    # _get_profile_dict()
 
     # Fetch data. This can all be done in parallel. The benchmarking is here
     # because this is the slowest part of the program, and it's helpful at
@@ -58,6 +58,7 @@ def get_data():
         print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
 
     # Parse data. This should only happen after all data has been fetched.
+    _parse_status(status_str)
     _parse_socials(socials_str)
     _parse_pr_activity(pr_activity_str)
     _parse_issue_activity(issue_activity_str)
@@ -73,9 +74,15 @@ def _fetch_status():
 def _parse_status(status_str):
     """Parse output of status call."""
     if "Logged in to github.com account " not in status_str:
-        msg = status_str
-        msg = "\nThe GitHub CLI tool (gh) is not authenticated."
-        msg += "Run `gh auth login` to authenticate."
+        # Show the stdout part of `gh auth status`, if there is any.
+        # I believe this is relevant when the user has an expired token.
+        if status_str:
+            msg = f"{status_str}\n"
+        else:
+            msg = ""
+
+        msg += "The GitHub CLI tool (gh) is not authenticated."
+        msg += "\nRun `gh auth login` to authenticate."
         sys.exit(msg)
 
 def _get_profile_dict():

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -14,9 +14,9 @@ from .profile_data import profile_data as pdata
 
 
 def ensure_gh():
-    """Make sure user has gh installed and is authenticated.
+    """Make sure user has gh installed.
 
-    Check for authentication issues in first external call, rather than making
+    Check for authentication issues in batch of external calls, rather than making
     a call just for that purpose here.
     """
     cmd = "gh --version"

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -43,10 +43,12 @@ def get_data():
     # times to benchmark just this block of code.
     ts_before = perf_counter()
     with ThreadPoolExecutor() as executor:
+        status_future = executor.submit(_fetch_status)
         socials_future = executor.submit(_fetch_socials)
         pr_activity_future = executor.submit(_fetch_pr_activity)
         issue_activity_future = executor.submit(_fetch_issue_activity)
 
+        status_str = status_future.result()
         socials_str = socials_future.result()
         pr_activity_str = pr_activity_future.result()
         issue_activity_str = issue_activity_future.result()
@@ -62,6 +64,19 @@ def get_data():
 
 
 # --- Helper functions ---
+
+def _fetch_status():
+    """Find out whether gh-profiler user is authenticated."""
+    cmd = "gh auth status"
+    return infra_utils.run_cmd(cmd)
+
+def _parse_status(status_str):
+    """Parse output of status call."""
+    if "Logged in to github.com account " not in status_str:
+        msg = status_str
+        msg = "\nThe GitHub CLI tool (gh) is not authenticated."
+        msg += "Run `gh auth login` to authenticate."
+        sys.exit(msg)
 
 def _get_profile_dict():
     """Get all the profile information we'll need."""

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -34,21 +34,19 @@ def get_data():
     Fetch all data we'll need, then parse it into the data structures that
     can be analyzed and processed.
     """
-    # This is the first call, and it checks if the user exists. This call needs
-    # to happen before all others.
-    # _get_profile_dict()
-
     # Fetch data. This can all be done in parallel. The benchmarking is here
     # because this is the slowest part of the program, and it's helpful at
-    # times to benchmark just this block of code.
+    # times to benchmark just this fetching code.
     ts_before = perf_counter()
     with ThreadPoolExecutor() as executor:
+        # Make fetching calls.
         status_future = executor.submit(_fetch_status)
         profile_dict_future = executor.submit(_fetch_profile_dict)
         socials_future = executor.submit(_fetch_socials)
         pr_activity_future = executor.submit(_fetch_pr_activity)
         issue_activity_future = executor.submit(_fetch_issue_activity)
 
+        # When each call finishes, store the result.
         status_str = status_future.result()
         profile_dict_str = profile_dict_future.result()
         socials_str = socials_future.result()


### PR DESCRIPTION
The older explicit check for auth status was removed to improve performance. The check for authentication against an actual call was less clear.

This PR makes an explicit auth check again, but does so from within the batched set of fetches. This performs reliably and quickly for users who are not authenticated, without any performance penalty for users who are authenticated.

Also, profile dict work is moved to the batched fetching workflow. Cleans up benchmarking script with clearer output, and a timeout of 5s per gh-profiler call.

Performance improves by about 0.25 sec when run against my own profile, about 0.10 sec when run against a more active user. More notably, performance improves even though we're making one more call than previously.

See #86.