### PR TITLE
New account with no other red/ yellow flags should be green.

### DIFF
--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -238,4 +238,5 @@ def _adjust_account_age_flag():
         return
 
     # The only issue is the account age flag. Set it green.
+    pdata.flag_age = flags.green_flag
     pdata.flag_overall_profile = flags.green_flag

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -17,6 +17,9 @@ def process_data():
 
     _set_overall_flags()
 
+    # This is a step done after all individual and group flags have been set.
+    _adjust_flags()
+
 
 # --- Helper functions ---
 
@@ -197,3 +200,42 @@ def _get_overall_flag(component_flags):
     if flags.yellow_flag in component_flags:
         return flags.yellow_flag
     return flags.green_flag
+
+def _adjust_flags():
+    """Make final adjustments to flags.
+
+    This takes place after all individual flags have been set, and all group
+    flags have been set based on flags within the group.
+
+    For example, if a newer account has no other red or yellow flags, we'll
+    adjust the account age flag to green.
+
+    Be careful about unintended effects. Especially as evaluation criteria gets
+    more complex, it would be easy to undo some reasoning implemented earlier.
+    """
+    _adjust_account_age_flag()
+
+def _adjust_account_age_flag():
+    """Reevaluate the account age flag.
+
+    If all other overall flags are green, the account age flag should be green.
+    This override only applies when all of the following are true:
+    - The overall profile flag is not green.
+    - The only individual profile flag that's not green is the account age.
+    - All other overall flags are green.
+    """
+    # Check for clear reasons this doesn't apply. Profile flag is already green,
+    # or another overall flag is not green.
+    if (
+        pdata.flag_overall_profile == flags.green_flag
+        or pdata.flag_overall_pr != flags.green_flag
+        or pdata.flag_overall_issues != flags.green_flag
+    ):
+        return
+    
+    # Check other profile component flags.
+    if pdata.flag_profiler != flags.green_flag:
+        return
+
+    # The only issue is the account age flag. Set it green.
+    pdata.flag_overall_profile = flags.green_flag

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -234,7 +234,7 @@ def _adjust_account_age_flag():
         return
     
     # Check other profile component flags.
-    if pdata.flag_profiler != flags.green_flag:
+    if pdata.flag_profile != flags.green_flag:
         return
 
     # The only issue is the account age flag. Set it green.

--- a/tests/unit_tests/test_adjust_flags.py
+++ b/tests/unit_tests/test_adjust_flags.py
@@ -12,3 +12,14 @@ def test_account_age_all_green():
 
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
+
+def test_account_age_yellow():
+    """Yellow age flag turns green when all others green."""
+    pdata.flag_age = flags.yellow_flag
+    pdata.flag_overall_profile = flags.yellow_flag
+
+    _adjust_account_age_flag()
+
+    assert pdata.flag_age == flags.green_flag
+    assert pdata.flag_overall_profile == flags.green_flag
+    

--- a/tests/unit_tests/test_adjust_flags.py
+++ b/tests/unit_tests/test_adjust_flags.py
@@ -22,4 +22,25 @@ def test_account_age_yellow():
 
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
+
+def test_account_age_red():
+    """Red age flag turns green when all others green."""
+    pdata.flag_age = flags.red_flag
+    pdata.flag_overall_profile = flags.red_flag
+
+    _adjust_account_age_flag()
+
+    assert pdata.flag_age == flags.green_flag
+    assert pdata.flag_overall_profile == flags.green_flag
+
+def test_issues_flag_yellow():
+    """Yellow age flag stays yellow when issues flag not green."""
+    pdata.flag_age = flags.yellow_flag
+    pdata.flag_overall_profile = flags.yellow_flag
+    pdata.flag_overall_issues = flags.yellow_flag
+
+    _adjust_account_age_flag()
+
+    assert pdata.flag_age == flags.yellow_flag
+    assert pdata.flag_overall_profile == flags.yellow_flag
     

--- a/tests/unit_tests/test_adjust_flags.py
+++ b/tests/unit_tests/test_adjust_flags.py
@@ -1,0 +1,14 @@
+"""Tests for making final adjustments to flags."""
+
+from gh_profiler.utils.profile_data import profile_data as pdata
+from gh_profiler.utils.analysis_utils import _adjust_account_age_flag
+from gh_profiler.utils import flags
+
+
+
+def test_account_age_all_green():
+    """Flags stay green when all are green."""
+    _adjust_account_age_flag()
+
+    assert pdata.flag_age == flags.green_flag
+    assert pdata.flag_overall_profile == flags.green_flag


### PR DESCRIPTION
This PR implements an `adjust_flags()` function, which runs after all other individual and overall flags have been set. It lets us make final adjustments based on cross-category flag combinations.

In this case, if the only issue a user has is that their account is newer, that yellow/red flag is adjusted to green. This avoids making newer, well-intentioned human contributors feel discouraged at seeing a yellow or red flag despite having taken no problematic actions.