### PR TITLE
Make summaries more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
-### Unreleased
+### 0.6.3
+
+#### External changes
+
+- Full summaries have the same section headers as concise summaries.
+- Messages are more consistent across categories, ie no usernames in detail lines.
+- More consistent alignment throughout summary.
+
+#### Internal changes
+
+- Simplified tests to make them less fragile. For example, only test lines relevant to the test, not the entire summary (except initial full summary test).
 
 #### External changes
 

--- a/README.md
+++ b/README.md
@@ -13,32 +13,34 @@ Running as a tool
 
 If you have uv installed, you can run this as a tool against any GitHub user:
 
-```sh
+```txt
 $ uvx gh-profiler <redacted>
 GitHub user: <redacted>
-  🟡 Account age: 159 days
+🟡 Some concerns found with user's profile.
+   🟡 Account age: 6 months
+   🟢 Profile information:
+        name: <redacted>
+        blog: <redacted>
+        email: <redacted>
+      Empty fields: company, location, bio
 
-  🟢 Profile information:
-      name: <redacted>
-      blog: https://<redacted>.com
-      email: info@<redacted>.com
-     Empty fields: company, location, bio
+🟢 No concerns found with recent PR activity.
+   🟢 Fewer than 10 PRs opened in the last 21 days.
 
-  🟢 <redacted> has opened fewer than 10 PRs in the last 21 days.
-
-  🔴 <redacted> has opened 6 new issues in the last 21 days.
-     🟢 0 issues have been closed as NOT_PLANNED.
-     🔴 6 issues were opened with the same title:
-        📋 Documentation Enhancement Suggestion (6)
+🔴 Significant concerns found with recent issue activity.
+   🔴 79 new issues opened in the last 21 days.
+   🟢 0 issues closed as NOT_PLANNED.
+   🔴 71 issues opened with the same title:
+        📋 Documentation Enhancement Suggestion (71)
 ```
 
 If you're working in your local project directory, you can simply provide a PR or issue number. The tool will look up the PR or issue, identify the user who opened it, and give a report on that user:
 
-```sh
+```txt
 $ uvx gh-profiler 8
 Issue #8: Accept a username or an issue/ pr number.
 Author: ehmatthes
-  🟢 Account age: 5,058 days
+  🟢 Account age: 13 years
   ...
 ```
 
@@ -51,7 +53,7 @@ You can also install the project, and then run the bare `gh-profiler` command:
 (.venv) $ pip install gh-profiler
 (.venv) $ gh-profiler ehmatthes
 GitHub user: ehmatthes
-  🟢 Account age: 5,058 days
+  🟢 Account age: 13 years
   ...
 ```
 
@@ -66,7 +68,7 @@ Concise output
 
 If you want just the simplest summary, you can pass the `--concise` flag:
 
-```sh
+```txt
 $ uvx gh-profiler <redacted> --concise
 GitHub user: <redacted>
 🟡 Some concerns found with user's profile.
@@ -118,11 +120,11 @@ Maintaining
 
 For live demos and screenshots, you can pass the `--redact` flag. The username and profile information sections will show "\<redacted\>" in place of identifying information:
 
-```sh
+```txt
 $ uv run gh-profiler 39 --redact
 Issue #39: Add a `--redact` flag
 Author: <redacted>
-  🟢 Account age: 5,058 days
+  🟢 Account age: 13 years
 
   🟢 Profile information:
       name: <redacted>

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -69,15 +69,37 @@ def _get_full_summary():
     # Include username, with label when appropriate.
     summary += _username_line()
 
+    # Include section header for profile.
+    summary += _get_concise_section(
+        pdata.flag_overall_profile,
+        "user's profile",
+    )
+
     # Always include account age.
     age = humanize.naturaldelta(pdata.account_age)
     summary += f"  {pdata.flag_age} Account age: {age}\n"
 
-    # Include profiler, PR activity, and issue activity sections.
+    # Include profile info.
     summary += _profile_summary()
     summary += "\n"
+
+    # Include section header for PR activity.
+    summary += _get_concise_section(
+        pdata.flag_overall_pr,
+        "recent PR activity",
+    )
+
+    # Include PR activity.
     summary += _pr_activity_summary()
     summary += "\n"
+
+    # Include section header for issue activity.
+    summary += _get_concise_section(
+        pdata.flag_overall_issues,
+        "recent issue activity",
+    )
+
+    #  Include issue activity.
     summary += _issue_activity_summary()
 
     return summary.strip()

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -76,7 +76,7 @@ def _get_full_summary():
     # Include profile info.
     summary += _get_profile_header()
     age = humanize.naturaldelta(pdata.account_age)
-    summary += f"  {pdata.flag_age} Account age: {age}\n"
+    summary += f"   {pdata.flag_age} Account age: {age}"
     summary += _profile_summary()
     summary += "\n"
 
@@ -139,15 +139,15 @@ def _username_line():
 def _profile_summary():
     """Summarize information from the user's profile dict."""
     if pdata.flag_profile == flags.red_flag:
-        return f"\n  {pdata.flag_profile} No profile information provided.\n"
+        return f"\n   {pdata.flag_profile} No profile information provided.\n"
 
     # Only show lines for fields that have information.
     # Collect empty fields for last line.
-    summary = f"\n  {pdata.flag_profile} Profile information:\n"
+    summary = f"\n   {pdata.flag_profile} Profile information:\n"
     empty_fields = []
     for k, v in pdata.profile_info.items():
         if v and k != "bio":
-            summary += f"      {k}: {v}\n"
+            summary += f"        {k}: {v}\n"
         elif v and k == "bio":
             summary += _bio_summary(v)
         else:
@@ -155,12 +155,12 @@ def _profile_summary():
 
     # Include socials.
     for social in pdata.socials:
-        summary += f"      {social['provider']}: {social['url']}\n"
+        summary += f"        {social['provider']}: {social['url']}\n"
 
     # List empty fields.
     if empty_fields:
         fields_str = ", ".join(empty_fields)
-        summary += f"     Empty fields: {fields_str}\n"
+        summary += f"      Empty fields: {fields_str}\n"
 
     return summary
 
@@ -183,15 +183,15 @@ def _bio_summary(bio):
 def _pr_activity_summary():
     """Summarize recent PR activity."""
     if pdata.opened_count < 10:
-        return f"  {flags.green_flag} {pdata.username} opened fewer than 10 PRs in the last 21 days.\n"
+        return f"   {flags.green_flag} {pdata.username} opened fewer than 10 PRs in the last 21 days.\n"
 
     summary = ""
     # Only show merged if it's a good sign.
     if pdata.flag_merged_pr == flags.green_flag:
-        summary += f"  {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs merged in the last 21 days.\n"
+        summary += f"   {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs merged in the last 21 days.\n"
 
     # Include number closed for everyone.
-    summary += f"  {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs closed without merging in the last 21 days.\n"
+    summary += f"   {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs closed without merging in the last 21 days.\n"
 
     return summary
 
@@ -199,17 +199,17 @@ def _pr_activity_summary():
 def _issue_activity_summary():
     """Summarize recent public issue activity."""
     if pdata.new_issue_count == 0:
-        return f"  {flags.green_flag} {pdata.username} opened no new issues in the last 21 days.\n"
+        return f"   {flags.green_flag} {pdata.username} opened no new issues in the last 21 days.\n"
 
-    summary = f"  {pdata.flag_overall_issues} {pdata.username} opened {pdata.new_issue_count} new issues in the last 21 days.\n"
-    summary += f"     {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues closed as NOT_PLANNED.\n"
+    summary = f"   {pdata.flag_overall_issues} {pdata.username} opened {pdata.new_issue_count} new issues in the last 21 days.\n"
+    summary += f"      {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues closed as NOT_PLANNED.\n"
 
     # Repeated issues:
     if pdata.total_repeats == 0:
-        summary += f"     {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title.\n"
+        summary += f"      {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title.\n"
     else:
-        summary += f"     {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title:\n"
+        summary += f"      {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title:\n"
     for title, count in pdata.repeated_issue_titles.items():
-        summary += f"        {title} ({count})\n"
+        summary += f"         {title} ({count})\n"
 
     return summary

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -196,7 +196,7 @@ def _pr_activity_summary():
 def _issue_activity_summary():
     """Summarize recent public issue activity."""
     if pdata.new_issue_count == 0:
-        return f"   {flags.green_flag} No new issues in the last 21 days.\n"
+        return f"   {flags.green_flag} No new issues opened in the last 21 days.\n"
 
     summary = f"   {pdata.flag_overall_issues} {pdata.new_issue_count} new issues opened in the last 21 days.\n"
     summary += f"   {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues closed as NOT_PLANNED.\n"
@@ -207,6 +207,6 @@ def _issue_activity_summary():
     else:
         summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title:\n"
     for title, count in pdata.repeated_issue_titles.items():
-        summary += f"      {title} ({count})\n"
+        summary += f"        {title} ({count})\n"
 
     return summary

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -27,7 +27,6 @@ def _get_concise_summary():
     This is one line for each main section: name, profile, pr activity, issue activity.
     """
     summary = ""
-
     summary += f"GitHub user: {pdata.username}\n"
     summary += _get_profile_header()
     summary += _get_pr_header()
@@ -49,6 +48,7 @@ def _get_issue_header():
     )
 
 def _get_section_header(flag, section):
+    """Return a single line header for each main section of the summary."""
     if flag == flags.green_flag:
         return f"{flag} No concerns found with {section}.\n"
     elif flag == flags.yellow_flag:
@@ -68,28 +68,20 @@ def _get_full_summary():
     # Include username, with label when appropriate.
     summary += _username_line()
 
-    # Include section header for profile.
+    # Include profile info.
     summary += _get_profile_header()
-
-    # Always include account age.
     age = humanize.naturaldelta(pdata.account_age)
     summary += f"  {pdata.flag_age} Account age: {age}\n"
-
-    # Include profile info.
     summary += _profile_summary()
     summary += "\n"
 
-    # Include section header for PR activity.
-    summary += _get_pr_header()
-
     # Include PR activity.
+    summary += _get_pr_header()
     summary += _pr_activity_summary()
     summary += "\n"
 
-    # Include section header for issue activity.
-    summary += _get_issue_header()
-
     #  Include issue activity.
+    summary += _get_issue_header()
     summary += _issue_activity_summary()
 
     return summary.strip()

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -21,9 +21,10 @@ def _get_summary():
     else:
         return _get_full_summary()
 
+
 def _get_concise_summary():
     """Build the shorter, concise summary string.
-    
+
     This is one line for each main section: name, profile, pr activity, issue activity.
     """
     summary = ""
@@ -35,17 +36,21 @@ def _get_concise_summary():
 
     return summary
 
+
 def _get_profile_header():
     return _get_section_header(pdata.flag_overall_profile, "user's profile")
 
+
 def _get_pr_header():
     return _get_section_header(pdata.flag_overall_pr, "recent PR activity")
+
 
 def _get_issue_header():
     return _get_section_header(
         pdata.flag_overall_issues,
         "recent issue activity",
     )
+
 
 def _get_section_header(flag, section):
     """Return a single line header for each main section of the summary."""
@@ -102,7 +107,7 @@ def _redact_info():
     for k, v in pdata.profile_info.items():
         if v:
             pdata.profile_info[k] = "<redacted>"
-    
+
     for social in pdata.socials:
         social["url"] = "<redacted>"
 

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -167,16 +167,13 @@ def _profile_summary():
 
 def _bio_summary(bio):
     """Summarize bio section of profile."""
-    if bio in (None, ""):
-        return f"        bio:\n"
-
     if bio.count("\n") == 0:
         return f"        bio: {bio}\n"
 
     # Print a multi-line bio.
     summary = "        bio:\n"
     for line in bio.splitlines():
-        summary += f"        {line}\n"
+        summary += f"          {line}\n"
     return summary
 
 

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -199,17 +199,17 @@ def _pr_activity_summary():
 def _issue_activity_summary():
     """Summarize recent public issue activity."""
     if pdata.new_issue_count == 0:
-        return f"   {flags.green_flag} {pdata.username} opened no new issues in the last 21 days.\n"
+        return f"   {flags.green_flag} No new issues in the last 21 days.\n"
 
-    summary = f"   {pdata.flag_overall_issues} {pdata.username} opened {pdata.new_issue_count} new issues in the last 21 days.\n"
-    summary += f"      {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues closed as NOT_PLANNED.\n"
+    summary = f"   {pdata.flag_overall_issues} {pdata.new_issue_count} new issues opened in the last 21 days.\n"
+    summary += f"   {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues closed as NOT_PLANNED.\n"
 
     # Repeated issues:
     if pdata.total_repeats == 0:
-        summary += f"      {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title.\n"
+        summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title.\n"
     else:
-        summary += f"      {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title:\n"
+        summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title:\n"
     for title, count in pdata.repeated_issue_titles.items():
-        summary += f"         {title} ({count})\n"
+        summary += f"      {title} ({count})\n"
 
     return summary

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -29,27 +29,26 @@ def _get_concise_summary():
     summary = ""
 
     summary += f"GitHub user: {pdata.username}\n"
-
-    summary += _get_concise_section(
-        pdata.flag_overall_profile,
-        "user's profile",
-    )
-
-    summary += _get_concise_section(
-        pdata.flag_overall_pr,
-        "recent PR activity",
-    )
-
-    summary += _get_concise_section(
-        pdata.flag_overall_issues,
-        "recent issue activity",
-    )
-
+    summary += _get_profile_header()
+    summary += _get_pr_header()
+    summary += _get_issue_header()
     summary += f"\nFor a more detailed report, run `gh-profiler {pdata.username}`."
 
     return summary
 
-def _get_concise_section(flag, section):
+def _get_profile_header():
+    return _get_section_header(pdata.flag_overall_profile, "user's profile")
+
+def _get_pr_header():
+    return _get_section_header(pdata.flag_overall_pr, "recent PR activity")
+
+def _get_issue_header():
+    return _get_section_header(
+        pdata.flag_overall_issues,
+        "recent issue activity",
+    )
+
+def _get_section_header(flag, section):
     if flag == flags.green_flag:
         return f"{flag} No concerns found with {section}.\n"
     elif flag == flags.yellow_flag:
@@ -70,10 +69,7 @@ def _get_full_summary():
     summary += _username_line()
 
     # Include section header for profile.
-    summary += _get_concise_section(
-        pdata.flag_overall_profile,
-        "user's profile",
-    )
+    summary += _get_profile_header()
 
     # Always include account age.
     age = humanize.naturaldelta(pdata.account_age)
@@ -84,20 +80,14 @@ def _get_full_summary():
     summary += "\n"
 
     # Include section header for PR activity.
-    summary += _get_concise_section(
-        pdata.flag_overall_pr,
-        "recent PR activity",
-    )
+    summary += _get_pr_header()
 
     # Include PR activity.
     summary += _pr_activity_summary()
     summary += "\n"
 
     # Include section header for issue activity.
-    summary += _get_concise_section(
-        pdata.flag_overall_issues,
-        "recent issue activity",
-    )
+    summary += _get_issue_header()
 
     #  Include issue activity.
     summary += _issue_activity_summary()

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -183,7 +183,7 @@ def _bio_summary(bio):
 def _pr_activity_summary():
     """Summarize recent PR activity."""
     if pdata.opened_count < 10:
-        return f"   {flags.green_flag} {pdata.username} opened fewer than 10 PRs in the last 21 days.\n"
+        return f"   {flags.green_flag} Fewer than 10 PRs opened in the last 21 days.\n"
 
     summary = ""
     # Only show merged if it's a good sign.

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -168,13 +168,13 @@ def _profile_summary():
 def _bio_summary(bio):
     """Summarize bio section of profile."""
     if bio in (None, ""):
-        return f"      bio:\n"
+        return f"        bio:\n"
 
     if bio.count("\n") == 0:
-        return f"      bio: {bio}\n"
+        return f"        bio: {bio}\n"
 
     # Print a multi-line bio.
-    summary = "      bio:\n"
+    summary = "        bio:\n"
     for line in bio.splitlines():
         summary += f"        {line}\n"
     return summary

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -66,3 +66,4 @@ def empty_profile_info():
     """
     pdata.profile_info = {}
     pdata.flag_profile = flags.red_flag
+    pdata.flag_overall_profile = flags.red_flag

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -2,31 +2,35 @@
 
 full_summary = """
 GitHub user: ehmatthes
-  🟢 Account age: 13 years
+🟢 No concerns found with user's profile.
+   🟢 Account age: 13 years
+   🟢 Profile information:
+        name: Eric Matthes
+        blog: https://www.mostlypython.com
+        location: western North Carolina
+        email: ehmatthes@gmail.com
+      Empty fields: company, bio
 
-  🟢 Profile information:
-      name: Eric Matthes
-      blog: https://www.mostlypython.com
-      location: western North Carolina
-      email: ehmatthes@gmail.com
-     Empty fields: company, bio
+🟢 No concerns found with recent PR activity.
+   🟢 Fewer than 10 PRs opened in the last 21 days.
 
-  🟢 ehmatthes opened fewer than 10 PRs in the last 21 days.
-
-  🟢 ehmatthes opened 7 new issues in the last 21 days.
-     🟢 0 issues closed as NOT_PLANNED.
-     🟢 0 issues opened with the same title.
+🟢 No concerns found with recent issue activity.
+   🟢 7 new issues opened in the last 21 days.
+   🟢 0 issues closed as NOT_PLANNED.
+   🟢 0 issues opened with the same title.
 """.strip()
 
 summary_empty_profile = """
 GitHub user: ehmatthes
-  🟢 Account age: 13 years
+🟢 No concerns found with user's profile.
+   🟢 Account age: 13 years
+   🔴 No profile information provided.
 
-  🔴 No profile information provided.
+🟢 No concerns found with recent PR activity.
+   🟢 Fewer than 10 PRs opened in the last 21 days.
 
-  🟢 ehmatthes opened fewer than 10 PRs in the last 21 days.
-
-  🟢 ehmatthes opened 7 new issues in the last 21 days.
-     🟢 0 issues closed as NOT_PLANNED.
-     🟢 0 issues opened with the same title.
+🟢 No concerns found with recent issue activity.
+   🟢 7 new issues opened in the last 21 days.
+   🟢 0 issues closed as NOT_PLANNED.
+   🟢 0 issues opened with the same title.
 """.strip()

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -19,18 +19,3 @@ GitHub user: ehmatthes
    🟢 0 issues closed as NOT_PLANNED.
    🟢 0 issues opened with the same title.
 """.strip()
-
-summary_empty_profile = """
-GitHub user: ehmatthes
-🔴 Significant concerns found with user's profile.
-   🟢 Account age: 13 years
-   🔴 No profile information provided.
-
-🟢 No concerns found with recent PR activity.
-   🟢 Fewer than 10 PRs opened in the last 21 days.
-
-🟢 No concerns found with recent issue activity.
-   🟢 7 new issues opened in the last 21 days.
-   🟢 0 issues closed as NOT_PLANNED.
-   🟢 0 issues opened with the same title.
-""".strip()

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -22,7 +22,7 @@ GitHub user: ehmatthes
 
 summary_empty_profile = """
 GitHub user: ehmatthes
-🟢 No concerns found with user's profile.
+🔴 Significant concerns found with user's profile.
    🟢 Account age: 13 years
    🔴 No profile information provided.
 

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -19,7 +19,9 @@ def test_summary():
 def test_summary_empty_profile(empty_profile_info):
     """Test summary for user with an empty profile."""
     summary = summary_utils._get_summary()
-    assert summary.strip() == reference_summaries.summary_empty_profile
+
+    assert "🔴 Significant concerns found with user's profile." in summary
+    assert "🔴 No profile information provided." in summary
 
 
 def test_no_issue_activity():

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -40,6 +40,14 @@ def test_redact():
     assert "ehmatthes" not in summary
     assert summary.count("<redacted") == 7
 
+def test_full_header_lines():
+    """The full summary should include the same header lines as concise."""
+    summary = summary_utils._get_summary()
+
+    assert "No concerns found with user's profile." in summary
+    assert "No concerns found with recent PR activity." in summary
+    assert "No concerns found with recent issue activity." in summary
+
 def test_concise():
     """Test output with pdata.concise set to True."""
     pdata.concise = True

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -27,7 +27,7 @@ def test_no_issue_activity():
     pdata.new_issue_count = 0
     summary = summary_utils._get_summary()
 
-    assert "🟢 ehmatthes opened no new issues in the last 21 days." in summary
+    assert "🟢 No new issues opened in the last 21 days." in summary
     assert "issues closed as NOT_PLANNED." not in summary
     assert "issues opened with the same title:" not in summary
 
@@ -38,7 +38,7 @@ def test_redact():
     summary = summary_utils._get_summary()
 
     assert "ehmatthes" not in summary
-    assert summary.count("<redacted") == 7
+    assert summary.count("<redacted") == 5
 
 def test_full_concise_header_lines():
     """The full summary should include the same header lines as concise."""

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -40,13 +40,18 @@ def test_redact():
     assert "ehmatthes" not in summary
     assert summary.count("<redacted") == 7
 
-def test_full_header_lines():
+def test_full_concise_header_lines():
     """The full summary should include the same header lines as concise."""
-    summary = summary_utils._get_summary()
+    summary_full = summary_utils._get_summary()
+    assert "No concerns found with user's profile." in summary_full
+    assert "No concerns found with recent PR activity." in summary_full
+    assert "No concerns found with recent issue activity." in summary_full
 
-    assert "No concerns found with user's profile." in summary
-    assert "No concerns found with recent PR activity." in summary
-    assert "No concerns found with recent issue activity." in summary
+    pdata.concise = True
+    summary_concise = summary_utils._get_summary()
+    assert "No concerns found with user's profile." in summary_concise
+    assert "No concerns found with recent PR activity." in summary_concise
+    assert "No concerns found with recent issue activity." in summary_concise
 
 def test_concise():
     """Test output with pdata.concise set to True."""


### PR DESCRIPTION
Full summaries have the same section headers as concise summaries. Messages are more consistent across categories, ie no usernames in detail lines. More consistent alignment throughout summary.

Simplified tests to make them less fragile. For example, only test lines relevant to the test, not the entire summary (except initial full summary test).

This will make it easier to include more analysis, while remaining readable.