### PR TITLE
If a user has 0 new PRs or issues, the profile flags are set to green.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### 0.6.4
+
+#### External changes
+
+- If a user has 0 new PRs or issues, the profile flags are set to green. This is important, for example, for people who have left GitHub and scrubbed their profile info, but not deleted their account. They haven't opened any PRs or issues, but they don't want to see yellow or red flags if someone runs gh-profiler against their account.
+- Supports `-v`, `--verbose`. When passed, this prints the rationale for adjust flags. This can expand to dump explanations for any decisions made in the analysis work.
+
+#### Internal changes
+
+- NA
+
 ### 0.6.3
 
 #### External changes

--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ When you've installed the project, you can also run it as a module:
 $ python -m gh_profiler <username>
 ```
 
+Verbose output
+---
+
+The `-v` or `--verbose` flag will print some of the rationales for evaluating flags:
+
+```txt
+$ uv run gh-profiler <redacted> -v
+
+Flag adjusted: Set account age flag green. This user has a newer account,
+  but they have no other concerning activity.
+
+Flags adjusted: Set profile info and overall profile flags green. This user has not
+  opened any recent PRs or issues, so they have no concerning activity.
+
+--- Summary ---
+
+GitHub user: <redacted>
+🟢 No concerns found with user's profile.
+   🟢 Account age: 20 minutes
+   🟢 Profile information:
+      Empty fields: name, company, blog, location, email, bio
+...
+```
+
 Concise output
 ---
 
@@ -77,6 +101,13 @@ GitHub user: <redacted>
 
 For a more detailed report, run `gh-profiler <redacted>`.
 ```
+
+False positives
+---
+
+Some checks are in place to ensure that people who are not engaged in clear problematic behavior don't raise red or yellow flags. For example, a new user who opens a bunch of identical issues or PRs will have a red flag for the account age. But a new user who does not show any other signs of problematic behavior will have their account age flag set to green.
+
+If you see an example of red or yellow flags being raised with no clear indication of problematic behavior, please consider opening an issue.
 
 GitHub Actions
 ---

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -18,9 +18,10 @@ from .utils.profile_data import profile_data as pdata
     is_flag=True,
     help="Generate a workflow that will automatically run `gh-profiler --concise` for every new PR and issue.",
 )
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output, including explanations for decisions about flags.")
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
 @click.option("--benchmark-fetch", is_flag=True, help="Benchmark the code that fetches external data.")
-def main(target, concise, generate_workflow, redact, benchmark_fetch):
+def main(target, concise, generate_workflow, verbose, redact, benchmark_fetch):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
@@ -36,10 +37,11 @@ def main(target, concise, generate_workflow, redact, benchmark_fetch):
     $ python -m gh_profiler ehmatthes
       ...
     """
-    _validate_command(target, concise, generate_workflow, redact, benchmark_fetch)
+    _validate_command(target, concise, generate_workflow, verbose, redact, benchmark_fetch)
 
     # Parse CLI options.
     pdata.concise = concise
+    pdata.verbose = verbose
     pdata.redact = redact
     pdata.benchmark_fetch = benchmark_fetch
     pdata.generate_workflow = generate_workflow
@@ -62,7 +64,7 @@ def main(target, concise, generate_workflow, redact, benchmark_fetch):
         cli_utils.process_pr_issue_num(pr_issue_num)
         gh_profiler.main()
 
-def _validate_command(target, concise, generate_workflow, redact, benchmark_fetch):
+def _validate_command(target, concise, generate_workflow, verbose, redact, benchmark_fetch):
     """Validate arguments that were passed in the CLI call."""
 
     # If target is not passed, --generate-workflow must be passed.

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -208,10 +208,10 @@ def _adjust_flags():
     flags have been set based on flags within the group.
 
     For example, if a newer account has no other red or yellow flags, we'll
-    adjust the account age flag to green.
+    adjust the profile flags to green.
 
-    Be careful about unintended effects. Especially as evaluation criteria gets
-    more complex, it would be easy to undo some reasoning implemented earlier.
+    Be careful about unintended effects. As evaluation criteria gets more
+    complex, it would be easy to undo some reasoning implemented earlier.
 
     These function names can be longer than typical names, more like test
     function names.
@@ -222,28 +222,29 @@ def _adjust_flags():
 def _adjust_account_age_flag():
     """Reevaluate the account age flag.
 
-    If all other overall flags are green, the account age flag should be green.
-    This override only applies when all of the following are true:
-    - The overall profile flag is not green.
-    - The only individual profile flag that's not green is the account age.
-    - All other overall flags are green.
+    If PR and issue flags are green, the account age flag should be green.
+    This applies when:
+    - The account age flag is not green.
+    - All other overall flags (PRs and issues) are green.
     """
-    # Check for clear reasons this doesn't apply. Profile flag is already green,
+    # Check for clear reasons this doesn't apply. Account age flag is already green,
     # or another overall flag is not green.
     if (
-        pdata.flag_overall_profile == flags.green_flag
+        pdata.flag_age == flags.green_flag
         or pdata.flag_overall_pr != flags.green_flag
         or pdata.flag_overall_issues != flags.green_flag
     ):
         return
-    
-    # Check other profile component flags.
-    if pdata.flag_profile != flags.green_flag:
-        return
 
-    # The only issue is the account age flag. Set it green.
+    # Set the account age flag green, and reevaluate overall profile flag.
     pdata.flag_age = flags.green_flag
-    pdata.flag_overall_profile = flags.green_flag
+    _process_profile_flags()
+
+    # Verbose rationale.
+    msg = "\nFlag adjusted: Set account age flag green. This user has a newer account,"
+    msg += "\n  but they have no other concerning activity."
+    if pdata.verbose:
+        print(msg)
 
 def _adjust_profile_flag_no_pr_issue_activity():
     """If user has no recent PRs or issues, profile flags should be green.
@@ -273,8 +274,8 @@ def _adjust_profile_flag_no_pr_issue_activity():
     pdata.flag_profile = flags.green_flag
     pdata.flag_overall_profile = flags.green_flag
 
+    # Verbose rationale.
     msg = "\nFlags adjusted: Set profile info and overall profile flags green. This user has not"
     msg += "\n  opened any recent PRs or issues, so they have no concerning activity."
     if pdata.verbose:
         print(msg)
-

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -212,8 +212,12 @@ def _adjust_flags():
 
     Be careful about unintended effects. Especially as evaluation criteria gets
     more complex, it would be easy to undo some reasoning implemented earlier.
+
+    These function names can be longer than typical names, more like test
+    function names.
     """
     _adjust_account_age_flag()
+    _adjust_profile_flag_no_pr_issue_activity()
 
 def _adjust_account_age_flag():
     """Reevaluate the account age flag.
@@ -240,3 +244,21 @@ def _adjust_account_age_flag():
     # The only issue is the account age flag. Set it green.
     pdata.flag_age = flags.green_flag
     pdata.flag_overall_profile = flags.green_flag
+
+def _adjust_profile_flag_no_pr_issue_activity():
+    """If user has no recent PRs or issues, profile flags should be green.
+    
+    This is meant to handle the specific situation where the target user has
+    had not recent PR or issue activity, and they have little or no profile
+    information. For example, people who have scrubbed their GH accounts but
+    not deleted their profile shouldn't raise any yellow or red flags.
+    
+    This should never come into play on a PR or issue. This should only come
+    into play when someone decides to run a profile against the user's account
+    for some other reason, such as curiosity. This was brought to my attention
+    by someone running gh-profiler on their own account, and feeling
+    uncomfortable about seeing flags raised despite no problematic activity.
+    """
+    if (pdata.opened_count == 0 and pdata.new_issue_count == 0):
+        pdata.flag_profile = flags.green_flag
+        pdata.flag_overall_profile = flags.green_flag

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -259,6 +259,22 @@ def _adjust_profile_flag_no_pr_issue_activity():
     by someone running gh-profiler on their own account, and feeling
     uncomfortable about seeing flags raised despite no problematic activity.
     """
-    if (pdata.opened_count == 0 and pdata.new_issue_count == 0):
-        pdata.flag_profile = flags.green_flag
-        pdata.flag_overall_profile = flags.green_flag
+    # Doesn't apply if there are any new PRs or issues.
+    if pdata.opened_count > 0 or pdata.new_issue_count > 0:
+        return
+
+    # Doesn't apply if relevant flags are already green.
+    if (
+        pdata.flag_profile == flags.green_flag
+        and pdata.flag_overall_profile == flags.green_flag
+    ):
+        return
+
+    pdata.flag_profile = flags.green_flag
+    pdata.flag_overall_profile = flags.green_flag
+
+    msg = "\nSet profile info and overall profile flags green. This user has not"
+    msg += "\nopened any recent PRs or issues, so they have no concerning activity."
+    if pdata.verbose:
+        print(msg)
+

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -273,8 +273,8 @@ def _adjust_profile_flag_no_pr_issue_activity():
     pdata.flag_profile = flags.green_flag
     pdata.flag_overall_profile = flags.green_flag
 
-    msg = "\nSet profile info and overall profile flags green. This user has not"
-    msg += "\nopened any recent PRs or issues, so they have no concerning activity."
+    msg = "\nFlags adjusted: Set profile info and overall profile flags green. This user has not"
+    msg += "\n  opened any recent PRs or issues, so they have no concerning activity."
     if pdata.verbose:
         print(msg)
 

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -62,6 +62,7 @@ class ProfileData:
 
     # --- Behavior fields ---
     concise: bool = False
+    verbose: bool = False
     # Redact is used primarily for live demos, and screenshots.
     redact: bool = False
 

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -8,6 +8,9 @@ from . import flags
 def show_summary():
     """Show a concise summary of what was found."""
     summary = _get_summary()
+
+    if pdata.verbose:
+        print("\n\n--- Summary ---\n")
     print(summary)
 
 

--- a/tests/unit_tests/test_adjust_flags.py
+++ b/tests/unit_tests/test_adjust_flags.py
@@ -1,14 +1,14 @@
 """Tests for making final adjustments to flags."""
 
 from gh_profiler.utils.profile_data import profile_data as pdata
-from gh_profiler.utils.analysis_utils import _adjust_account_age_flag
+from gh_profiler.utils import analysis_utils
 from gh_profiler.utils import flags
 
 
 
 def test_account_age_all_green():
     """Flags stay green when all are green."""
-    _adjust_account_age_flag()
+    analysis_utils._adjust_account_age_flag()
 
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
@@ -18,7 +18,7 @@ def test_account_age_yellow():
     pdata.flag_age = flags.yellow_flag
     pdata.flag_overall_profile = flags.yellow_flag
 
-    _adjust_account_age_flag()
+    analysis_utils._adjust_account_age_flag()
 
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
@@ -28,7 +28,7 @@ def test_account_age_red():
     pdata.flag_age = flags.red_flag
     pdata.flag_overall_profile = flags.red_flag
 
-    _adjust_account_age_flag()
+    analysis_utils._adjust_account_age_flag()
 
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
@@ -39,8 +39,20 @@ def test_issues_flag_yellow():
     pdata.flag_overall_profile = flags.yellow_flag
     pdata.flag_overall_issues = flags.yellow_flag
 
-    _adjust_account_age_flag()
+    analysis_utils._adjust_account_age_flag()
 
     assert pdata.flag_age == flags.yellow_flag
     assert pdata.flag_overall_profile == flags.yellow_flag
+
+def test_no_pr_issue_activity():
+    """If a user has not opened any recent PRs or issues, profile is green."""
+    pdata.flag_profile = flags.yellow_flag
+    pdata.flag_overall_profile = flags.yellow_flag
+    pdata.opened_count = 0
+    pdata.new_issue_count = 0
+
+    analysis_utils._adjust_profile_flag_no_pr_issue_activity()
+
+    assert pdata.flag_profile == flags.green_flag
+    assert pdata.flag_overall_profile == flags.green_flag
     


### PR DESCRIPTION
This is important, for example, for people who have left GitHub and scrubbed their profile info, but not deleted their account. They haven't opened any PRs or issues, but they don't want to see yellow or red flags if someone runs gh-profiler against their account.

Supports `-v`, `--verbose`. When passed, this prints the rationale for adjust flags. This can expand to dump explanations for any decisions made in the analysis work.

See #93.