### PR TITLE
Write a longer test that checks output against a number of actual users, without including those usernames in repo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### Unreleased
+
+#### External changes
+
+- NA
+
+#### Internal changes
+
+- Includes `developer_resources/test_actual_users.py`, which runs tests against a series of actual users.
+  - Targets users in `actual_users.toml`, which is stored outside this repo so as not to call attention to any specific users.
+  - Targets users who should only ever return green flags, and users who are expected to raise at least one yellow or red flag.
+  - Includes a template data file in `developer_resources/actual_users.toml`.
+- Implements better timeouts and checks for empty API responses in e2e tests.
+
 ### 0.6.4
 
 #### External changes

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ $ uv run pytest tests/e2e_tests
 There's a test that runs against a longer set of actual users. It pulls from a data file that's stored outside this repo, because we don't want to call attention to any specific users. There's an empty data file template in `developer_resources/`, for people who want to start testing against actual users.
 
 ```sh
+$ export PATH_ACTUAL_USERS=<path/to/actual_users.toml>
 $ uv run pytest developer_resources/test_actual_users.py -s
 ```
 

--- a/README.md
+++ b/README.md
@@ -178,14 +178,21 @@ Run all tests except end-to-end tests:
 $ uv run pytest
 ```
 
-End-to-end tests are slower, and flakier because they make actual API calls. It's best to run a specific e2e test:
+End-to-end tests are slower because they make actual API calls. You have to run them explicitly:
 
 ```sh
-$ uv run pytest tests/e2e_tests -k full
-$ uv run pytest tests/e2e_tests -k concise
+$ uv run pytest tests/e2e_tests
 ```
 
-There's a shell script that runs all of these tests. It works on macOS and probably linux, but may not work on Windows.
+There's a test that runs against a longer set of actual users. It pulls from a data file that's stored outside this repo, because we don't want to call attention to any specific users. There's an empty data file template in `developer_resources/`, for people who want to start testing against actual users.
+
+```sh
+$ uv run pytest developer_resources/test_actual_users.py -s
+```
+
+The `-s` flag is helpful to see each user account that's being tested. For fuller documentation, see the comments in `test_actual_users.py`. This test will likely be moved to `tests/e2e_tests/`, but the usernames will always be kept outside this repo.
+
+There's a shell script that runs all these tests. It works on macOS and probably linux, but may not work on Windows.
 
 ```sh
 $ ./test_all.sh

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 """Root conftest.py"""
 
+# Any tests in developer_resources/ are meant to be run manually.
 # Don't collect e2e tests; only run when specified over CLI.
-collect_ignore = ["tests/e2e_tests"]
+collect_ignore = ["developer_resources", "tests/e2e_tests"]

--- a/conftest.py
+++ b/conftest.py
@@ -3,8 +3,3 @@
 # Any tests in developer_resources/ are meant to be run manually.
 # Don't collect e2e tests; only run when specified over CLI.
 collect_ignore = ["developer_resources", "tests/e2e_tests"]
-
-# CLI arg for path to file containing actual usernames to test against.
-# This is used in developer_resources/test_actual_users.py.
-def pytest_addoption(parser):
-    parser.addoption("--path-actual-usernames", action="store", default="")

--- a/conftest.py
+++ b/conftest.py
@@ -3,3 +3,8 @@
 # Any tests in developer_resources/ are meant to be run manually.
 # Don't collect e2e tests; only run when specified over CLI.
 collect_ignore = ["developer_resources", "tests/e2e_tests"]
+
+# CLI arg for path to file containing actual usernames to test against.
+# This is used in developer_resources/test_actual_users.py.
+def pytest_addoption(parser):
+    parser.addoption("--path-actual-usernames", action="store", default="")

--- a/developer_resources/actual_users.toml
+++ b/developer_resources/actual_users.toml
@@ -1,0 +1,34 @@
+# Actual GH user profiles to test against.
+# 
+# This is a template file. If you want to run
+# developer_resources/test_actual_users.py, copy this file to a location
+# outside the gh-profiler repo. Then add the actual usernames you want
+# to test against.
+# 
+# A version of this file with actual usernames should never be checked in.
+# 
+# To run the test:
+# - Set PATH_ACTUAL_USERS to the location you saved this file.
+# - Run `uv run pytest developer_resources/test_actual_users.py`.
+# 
+# If your file is not being found, run with the `-rs` flag to see the 
+# the path that's being used.
+
+
+# Accounts that should only ever return green flags.
+green_users = [
+    # Me.
+
+    # Collaborators and known prominent open source people.
+
+    # New users, who have never engaged in known problematic behavior.
+
+    # Users who have left GH, but haven't deleted their account.
+
+]
+
+
+# Accounts that should always raise at least one non-green flag.
+non_green_users = [
+
+]

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -1,0 +1,50 @@
+"""Run tests against real-world users.
+
+This test runs against a set of users known to have all green appropriate
+behaviors, and users known to have problematic behaviors.
+
+It fails on any non-green flag in known green user profiles.
+It fails on all-green results for known problematic users.
+
+The user lists are entirely private and will never be posted publicly. This is
+meant to help make sure we're not actually flagging appropriate behaviors, or
+not catching inappropriate behaviors.
+
+When a test fails, it doesn't necessarily mean there's a problem with
+gh-profiler. When this test fails, we should look at that user's profile. If
+they are expected to be all green, we should see if there's a legitimate
+behavior that's being flagged. If they're expected not to be all green, we 
+should see if the user has stopped being active, has improved their activity,
+or if we're just not catching something.
+
+The target file should be a .py file, with two lists:
+  green_users, and non_green_users.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def path_actual_usernames(request):
+    path = request.config.getoption("--path-actual-usernames")
+    if path:
+        path = Path(path)
+    else:
+        path_src_dir = Path(__file__).parents[2]
+        path = path_src_dir / "gh-profiler_support" / "actual_users.py"
+    
+    if path.exists():
+        return path
+    else:
+        msg = "No actual_users.py file found."
+        breakpoint()
+        pytest.exit(msg)
+
+
+
+def test_actual_users(path_actual_usernames):
+    """Run gh-profiler against actual users, and look for appropriate flags.
+    """
+    assert False    

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -33,6 +33,8 @@ from gh_profiler.utils import infra_utils
 from gh_profiler.utils import flags
 
 
+# --- Fixtures ---
+
 @pytest.fixture()
 def path_actual_usernames(request):
     path = request.config.getoption("--path-actual-usernames")
@@ -50,6 +52,8 @@ def path_actual_usernames(request):
         pytest.exit(msg)
 
 
+# --- Helper functions ---
+
 def run_with_timeout(cmd):
     """Run gh-profiler command, with a timeout."""
     num_attempts = 0
@@ -66,6 +70,7 @@ def run_with_timeout(cmd):
     pytest.exit(msg)
 
 
+# --- Test functions ---
 
 def test_actual_users(path_actual_usernames):
     """Run gh-profiler against actual users, and look for appropriate flags.

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -36,7 +36,8 @@ from gh_profiler.utils import flags
 # --- Fixtures ---
 
 @pytest.fixture()
-def path_actual_usernames(request):
+def usernames_data(request):
+    """Return data object containing green and non-green user lists."""
     path = request.config.getoption("--path-actual-usernames")
     if path:
         path = Path(path)
@@ -44,12 +45,24 @@ def path_actual_usernames(request):
         path_src_dir = Path(__file__).parents[2]
         path = path_src_dir / "gh-profiler_support" / "actual_users.toml"
     
-    if path.exists():
-        return path
-    else:
+    if not path.exists():
         msg = "No actual_users.py file found."
-        breakpoint()
         pytest.exit(msg)
+
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    
+    return data
+
+@pytest.fixture()
+def green_users(usernames_data):
+    """Return only green users."""
+    return usernames_data["green_users"]
+
+@pytest.fixture()
+def non_green_users(usernames_data):
+    """Return only non-green users."""
+    return usernames_data["non_green_users"]
 
 
 # --- Helper functions ---
@@ -71,23 +84,20 @@ def run_with_timeout(cmd):
 
 
 # --- Test functions ---
-
-def test_actual_users(path_actual_usernames):
-    """Run gh-profiler against actual users, and look for appropriate flags.
-    """
-    with path_actual_usernames.open("rb") as f:
-        data = tomllib.load(f)
-
-    print("\nTesting green users...")
-    for username in data["green_users"]:
-        print(f"  Testing against {username}")
+def test_green_user(green_users):
+    """Run gh-profiler against known green users."""
+    print("Testing green users...")
+    for username in green_users:
+        print(f"  Testing against green user {username}")
         cmd = f"uv run gh-profiler {username} --concise"
         output = run_with_timeout(cmd)
 
         assert output.count(flags.green_flag) == 3
 
+def test_non_green_users(non_green_users):
+    """Run gh-profiler against known non-green users."""
     print("Testing non-green users...")
-    for username in data["non_green_users"]:
+    for username in non_green_users:
         print(f"  Testing against {username}")
         cmd = f"uv run gh-profiler {username} --concise"
         output = run_with_timeout(cmd)

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -21,6 +21,10 @@ The target file should be a .toml file, with two lists:
   green_users, and non_green_users.
 We're using TOML so we can have comments in the data file. I like to keep track
 of why I'm testing against certain users.
+
+If your data file isn't being found, you can see what path is being used
+with this command:
+    uv run pytest developer_resources/test_actual_users.py -rs
 """
 
 from pathlib import Path
@@ -47,7 +51,7 @@ def get_users(category):
     
     if not path.exists():
         msg = f"No actual_users.toml file found. Tried {path}"
-        pytest.exit(msg)
+        pytest.skip(msg, allow_module_level=True)
 
     with path.open("rb") as f:
         data = tomllib.load(f)

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -73,11 +73,18 @@ def test_actual_users(path_actual_usernames):
     with path_actual_usernames.open("rb") as f:
         data = tomllib.load(f)
 
+    print("\nTesting green users...")
     for username in data["green_users"]:
-        print(f"Testing against {username}...")
+        print(f"  Testing against {username}")
         cmd = f"uv run gh-profiler {username} --concise"
         output = run_with_timeout(cmd)
 
         assert output.count(flags.green_flag) == 3
 
-    
+    print("Testing non-green users...")
+    for username in data["non_green_users"]:
+        print(f"  Testing against {username}")
+        cmd = f"uv run gh-profiler {username} --concise"
+        output = run_with_timeout(cmd)
+
+        assert output.count(flags.green_flag) < 3

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -6,21 +6,24 @@ behaviors, and users known to have problematic behaviors.
 It fails on any non-green flag in known green user profiles.
 It fails on all-green results for known problematic users.
 
-The user lists are entirely private and will never be posted publicly. This is
-meant to help make sure we're not actually flagging appropriate behaviors, or
-not catching inappropriate behaviors.
+The user lists are entirely private and will never be in the public repo. This
+test helps make sure we're not accidentally flagging appropriate behaviors, or
+missing inappropriate behaviors.
 
-When a test fails, it doesn't necessarily mean there's a problem with
-gh-profiler. When this test fails, we should look at that user's profile. If
-they are expected to be all green, we should see if there's a legitimate
-behavior that's being flagged. If they're expected not to be all green, we 
-should see if the user has stopped being active, has improved their activity,
-or if we're just not catching something.
+When this test fails, it doesn't necessarily mean there's a problem with
+gh-profiler. When it fails, we should look at that user's profile. If
+they're expected to be all green, we should see if there's a legitimate
+behavior that's being flagged. If they're expected to raise yellow or red flags,
+we should see if the user has stopped being active, has improved their activity,
+or if we're missing something.
 
-The target file should be a .toml file, with two lists:
-  green_users, and non_green_users.
-We're using TOML so we can have comments in the data file. I like to keep track
-of why I'm testing against certain users.
+The target file should be a .toml file, with two lists: green_users, and
+non_green_users. We're using TOML so we can have comments in the data file.
+I like to keep track of why I'm testing against certain users. You can see a
+sample actual_users.toml file in developer_resources/.
+
+Running this test:
+    uv run pytest developer_resources/test_actual_users.py -s
 
 If your data file isn't being found, you can see what path is being used
 with this command:

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -71,7 +71,13 @@ def run_with_timeout(cmd):
             print("Time out.")
             num_attempts += 1
         else:
-            return output
+            # Did not time out, but check that we got a response.
+            if output:
+                return output
+            else:
+                print("Got an empty response.")
+                num_attempts += 1
+                continue
     
     msg = "Too many timeouts."
     pytest.exit(msg)

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -26,6 +26,7 @@ of why I'm testing against certain users.
 from pathlib import Path
 import tomllib
 import subprocess
+import os
 
 import pytest
 
@@ -35,10 +36,9 @@ from gh_profiler.utils import flags
 
 # --- Fixtures ---
 
-@pytest.fixture()
-def usernames_data(request):
+def get_users(category):
     """Return data object containing green and non-green user lists."""
-    path = request.config.getoption("--path-actual-usernames")
+    path = os.environ.get("PATH_ACTUAL_USERS", None)
     if path:
         path = Path(path)
     else:
@@ -52,17 +52,10 @@ def usernames_data(request):
     with path.open("rb") as f:
         data = tomllib.load(f)
     
-    return data
-
-@pytest.fixture()
-def green_users(usernames_data):
-    """Return only green users."""
-    return usernames_data["green_users"]
-
-@pytest.fixture()
-def non_green_users(usernames_data):
-    """Return only non-green users."""
-    return usernames_data["non_green_users"]
+    if category == "green":
+        return data["green_users"]
+    elif category == "non_green":
+        return data["non_green_users"]
 
 
 # --- Helper functions ---
@@ -84,8 +77,9 @@ def run_with_timeout(cmd):
 
 
 # --- Test functions ---
-def test_green_users(green_users):
+def test_green_users():
     """Run gh-profiler against known green users."""
+    green_users = get_users("green")
     print("\n\nTesting green users...")
     for username in green_users:
         print(f"  Testing against green user {username}")
@@ -94,8 +88,9 @@ def test_green_users(green_users):
 
         assert output.count(flags.green_flag) == 3
 
-def test_non_green_users(non_green_users):
+def test_non_green_users():
     """Run gh-profiler against known non-green users."""
+    non_green_users = get_users("non_green")
     print("\n\nTesting non-green users...")
     for username in non_green_users:
         print(f"  Testing against non-green user {username}")

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -17,13 +17,20 @@ behavior that's being flagged. If they're expected not to be all green, we
 should see if the user has stopped being active, has improved their activity,
 or if we're just not catching something.
 
-The target file should be a .py file, with two lists:
+The target file should be a .toml file, with two lists:
   green_users, and non_green_users.
+We're using TOML so we can have comments in the data file. I like to keep track
+of why I'm testing against certain users.
 """
 
 from pathlib import Path
+import tomllib
+import subprocess
 
 import pytest
+
+from gh_profiler.utils import infra_utils
+from gh_profiler.utils import flags
 
 
 @pytest.fixture()
@@ -33,7 +40,7 @@ def path_actual_usernames(request):
         path = Path(path)
     else:
         path_src_dir = Path(__file__).parents[2]
-        path = path_src_dir / "gh-profiler_support" / "actual_users.py"
+        path = path_src_dir / "gh-profiler_support" / "actual_users.toml"
     
     if path.exists():
         return path
@@ -43,8 +50,34 @@ def path_actual_usernames(request):
         pytest.exit(msg)
 
 
+def run_with_timeout(cmd):
+    """Run gh-profiler command, with a timeout."""
+    num_attempts = 0
+    while num_attempts < 5:
+        try:
+            output = infra_utils.run_cmd(cmd, timeout=5)
+        except subprocess.TimeoutExpired:
+            print("Time out.")
+            num_attempts += 1
+        else:
+            return output
+    
+    msg = "Too many timeouts."
+    pytest.exit(msg)
+
+
 
 def test_actual_users(path_actual_usernames):
     """Run gh-profiler against actual users, and look for appropriate flags.
     """
-    assert False    
+    with path_actual_usernames.open("rb") as f:
+        data = tomllib.load(f)
+
+    for username in data["green_users"]:
+        print(f"Testing against {username}...")
+        cmd = f"uv run gh-profiler {username} --concise"
+        output = run_with_timeout(cmd)
+
+        assert output.count(flags.green_flag) == 3
+
+    

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -86,7 +86,7 @@ def run_with_timeout(cmd):
 # --- Test functions ---
 def test_green_users(green_users):
     """Run gh-profiler against known green users."""
-    print("Testing green users...")
+    print("\n\nTesting green users...")
     for username in green_users:
         print(f"  Testing against green user {username}")
         cmd = f"uv run gh-profiler {username} --concise"
@@ -96,9 +96,9 @@ def test_green_users(green_users):
 
 def test_non_green_users(non_green_users):
     """Run gh-profiler against known non-green users."""
-    print("Testing non-green users...")
+    print("\n\nTesting non-green users...")
     for username in non_green_users:
-        print(f"  Testing against {username}")
+        print(f"  Testing against non-green user {username}")
         cmd = f"uv run gh-profiler {username} --concise"
         output = run_with_timeout(cmd)
 

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -77,16 +77,16 @@ def run_with_timeout(cmd):
 
 
 # --- Test functions ---
-def test_green_users():
-    """Run gh-profiler against known green users."""
-    green_users = get_users("green")
-    print("\n\nTesting green users...")
-    for username in green_users:
-        print(f"  Testing against green user {username}")
-        cmd = f"uv run gh-profiler {username} --concise"
-        output = run_with_timeout(cmd)
 
-        assert output.count(flags.green_flag) == 3
+
+@pytest.mark.parametrize("username", get_users("green"))
+def test_green_users(username):
+    """Run gh-profiler against known green users."""
+    print(f"\nTesting against green user {username}")
+    cmd = f"uv run gh-profiler {username} --concise"
+    output = run_with_timeout(cmd)
+
+    assert output.count(flags.green_flag) == 3
 
 def test_non_green_users():
     """Run gh-profiler against known non-green users."""

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -84,7 +84,7 @@ def run_with_timeout(cmd):
 
 
 # --- Test functions ---
-def test_green_user(green_users):
+def test_green_users(green_users):
     """Run gh-profiler against known green users."""
     print("Testing green users...")
     for username in green_users:

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -88,13 +88,11 @@ def test_green_users(username):
 
     assert output.count(flags.green_flag) == 3
 
-def test_non_green_users():
+@pytest.mark.parametrize("username", get_users("non_green"))
+def test_non_green_users(username):
     """Run gh-profiler against known non-green users."""
-    non_green_users = get_users("non_green")
-    print("\n\nTesting non-green users...")
-    for username in non_green_users:
-        print(f"  Testing against non-green user {username}")
-        cmd = f"uv run gh-profiler {username} --concise"
-        output = run_with_timeout(cmd)
+    print(f"\nTesting against non-green user {username}")
+    cmd = f"uv run gh-profiler {username} --concise"
+    output = run_with_timeout(cmd)
 
-        assert output.count(flags.green_flag) < 3
+    assert output.count(flags.green_flag) < 3

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -34,7 +34,7 @@ from gh_profiler.utils import infra_utils
 from gh_profiler.utils import flags
 
 
-# --- Fixtures ---
+# --- Helper functions ---
 
 def get_users(category):
     """Return data object containing green and non-green user lists."""
@@ -57,9 +57,6 @@ def get_users(category):
     elif category == "non_green":
         return data["non_green_users"]
 
-
-# --- Helper functions ---
-
 def run_with_timeout(cmd):
     """Run gh-profiler command, with a timeout."""
     num_attempts = 0
@@ -78,21 +75,27 @@ def run_with_timeout(cmd):
 
 # --- Test functions ---
 
-
 @pytest.mark.parametrize("username", get_users("green"))
 def test_green_users(username):
-    """Run gh-profiler against known green users."""
+    """Run gh-profiler against known green users.
+    
+    We should not find any yellow or red flags for these users.
+    """
     print(f"\nTesting against green user {username}")
     cmd = f"uv run gh-profiler {username} --concise"
     output = run_with_timeout(cmd)
 
-    assert output.count(flags.green_flag) == 3
+    assert flags.yellow_flag not in output
+    assert flags.red_flag not in output
 
 @pytest.mark.parametrize("username", get_users("non_green"))
 def test_non_green_users(username):
-    """Run gh-profiler against known non-green users."""
+    """Run gh-profiler against known non-green users.
+    
+    We should find at least one yellow or red flag for these users.
+    """
     print(f"\nTesting against non-green user {username}")
     cmd = f"uv run gh-profiler {username} --concise"
     output = run_with_timeout(cmd)
 
-    assert output.count(flags.green_flag) < 3
+    assert flags.yellow_flag in output or flags.red_flag in output

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -46,7 +46,7 @@ def get_users(category):
         path = path_src_dir / "gh-profiler_support" / "actual_users.toml"
     
     if not path.exists():
-        msg = "No actual_users.py file found."
+        msg = f"No actual_users.toml file found. Tried {path}"
         pytest.exit(msg)
 
     with path.open("rb") as f:

--- a/src/gh_profiler/utils/infra_utils.py
+++ b/src/gh_profiler/utils/infra_utils.py
@@ -11,8 +11,8 @@ DEFAULT_ENV = {
 }
 
 
-def run_cmd(cmd, env=DEFAULT_ENV):
+def run_cmd(cmd, env=DEFAULT_ENV, timeout=None):
     """Run a subprocess command, return stdout."""
     cmd_parts = shlex.split(cmd)
-    output_obj = subprocess.run(cmd_parts, capture_output=True, env=env)
+    output_obj = subprocess.run(cmd_parts, capture_output=True, env=env, timeout=timeout)
     return output_obj.stdout.decode()

--- a/test_all.sh
+++ b/test_all.sh
@@ -8,8 +8,7 @@
 uv run pytest
 
 # E2e tests.
-uv run pytest tests/e2e_tests -k full
-uv run pytest tests/e2e_tests -k concise
+uv run pytest tests/e2e_tests
 
 # Tests against actual users.
 uv run pytest developer_resources/test_actual_users.py -s

--- a/test_all.sh
+++ b/test_all.sh
@@ -4,6 +4,12 @@
 # If they're taking much longer than a few seconds, it's probably worth
 # cancelling the run and run again.
 
+# Unit tests.
 uv run pytest
+
+# E2e tests.
 uv run pytest tests/e2e_tests -k full
 uv run pytest tests/e2e_tests -k concise
+
+# Tests against actual users.
+uv run pytest developer_resources/test_actual_users.py -s

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -25,7 +25,13 @@ def run_with_timeout(cmd):
             print("Time out.")
             num_attempts += 1
         else:
-            return output
+            # Did not time out, but check that we got a response.
+            if output:
+                return output
+            else:
+                print("Got an empty response.")
+                num_attempts += 1
+                continue
     
     # Skip this entire module if there are too many timeouts.
     msg = "Too many timeouts."

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -27,9 +27,9 @@ def run_with_timeout(cmd):
         else:
             return output
     
-    # Use a sys exit, not pytest. pytest.exit would exit the whole suite?
+    # Skip this entire module if there are too many timeouts.
     msg = "Too many timeouts."
-    sys.exit(msg)
+    pytest.skip(msg, allow_module_level=True)
 
 
 # --- Test functions ---

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -5,15 +5,38 @@ Makes an actual gh-profiler call. Currently calls against my own user account
 to use.
 """
 
+import sys
+
 import pytest
 
 from gh_profiler.utils import infra_utils
 
 
+# --- Helper functions ---
+
+def run_with_timeout(cmd):
+    """Run gh-profiler command, with a timeout."""
+    num_attempts = 0
+    while num_attempts < 5:
+        try:
+            output = infra_utils.run_cmd(cmd, timeout=5)
+        except subprocess.TimeoutExpired:
+            print("Time out.")
+            num_attempts += 1
+        else:
+            return output
+    
+    # Use a sys exit, not pytest. pytest.exit would exit the whole suite?
+    msg = "Too many timeouts."
+    sys.exit(msg)
+
+
+# --- Test functions ---
+
 def test_full_run():
     """Test a standard run of gh-profiler."""
     cmd = "uv run gh-profiler ehmatthes"
-    output = infra_utils.run_cmd(cmd)
+    output = run_with_timeout(cmd)
 
     if output == "":
         msg = "Output was empty, which may indicate a gh timeout rather than a problem with the code."
@@ -35,7 +58,7 @@ def test_full_run():
 def test_concise_run():
     """Test a --concise run of gh-profiler."""
     cmd = "uv run gh-profiler ehmatthes --concise"
-    output = infra_utils.run_cmd(cmd)
+    output = run_with_timeout(cmd)
 
     if output == "":
         msg = "Output was empty, which may indicate a gh timeout rather than a problem with the code."

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -6,6 +6,7 @@ to use.
 """
 
 import sys
+import subprocess
 
 import pytest
 


### PR DESCRIPTION
As the project evolves, people continue to be concerned that well-intentioned users will be flagged inappropriately. Many of these concerns reflect specific situations, such as brand new GH users.

These situations are covered in unit tests by testing against example profile data, but that's not as reassuring as running the tool against actual users. The unit tests say "if a profile looks like this, we'll get this set of flags." This test against actual users says, "An actual user fitting this demographic returns the expected set of flags."

I never want this repo to call attention to any specific GH user, so all usernames are stored outside the repo.

From changelog:

- Includes `developer_resources/test_actual_users.py`, which runs tests against a series of actual users.
  - Targets users in `actual_users.toml`, which is stored outside this repo so as not to call attention to any specific users.
  - Targets users who should only ever return green flags, and users who are expected to raise at least one yellow or red flag.
  - Includes a template data file in `developer_resources/actual_users.toml`.
- Implements better timeouts and checks for empty API responses in e2e tests.