### PR TITLE
Focus PR analysis on PRs opened against external repos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
-### Unreleased
+### 0.6.5
 
 #### External changes
 
-- NA
+- Reports number of PRs opened, regardless of how many. (Previously did not report specifics under 10 PRs.)
+- Differentiates between PRs opened against repos the user owns, vs external repos.
+- Added note to README about not flagging good-faith behavior.
 
 #### Internal changes
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Many of us have received waves of open source contributions where many of the ne
 
 This meant to give you some quick context about how much to invest in reviewing the PR. It's not meant to give an immediate signal to close the PR or issue.
 
+This tool should not flag anyone making good-faith efforts to contribute to open source projects. If you think it is, please open an issue and describe the behavior that's being flagged.
+
 Running as a tool
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ GitHub user: <redacted>
       Empty fields: company, location, bio
 
 🟢 No concerns found with recent PR activity.
-   🟢 Fewer than 10 PRs opened in the last 21 days.
+   2 PRs opened in the last 21 days.
+      0 opened against repos the user owns.
+      2 opened against external repos.
+
+   🟢 1 of 2 external PRs merged in the last 21 days.
+   🟢 1 of 2 external PRs closed without merging in the last 21 days.
 
 🔴 Significant concerns found with recent issue activity.
    🔴 79 new issues opened in the last 21 days.
-   🟢 0 issues closed as NOT_PLANNED.
-   🔴 71 issues opened with the same title:
-        📋 Documentation Enhancement Suggestion (71)
+   🟢 1 issues closed as NOT_PLANNED.
+   🔴 70 issues opened with the same title:
+        📋 Documentation Enhancement Suggestion (70)
 ```
 
 If you're working in your local project directory, you can simply provide a PR or issue number. The tool will look up the PR or issue, identify the user who opened it, and give a report on that user:

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -68,15 +68,28 @@ def _process_profile_info():
 
 
 def _process_pr_activity():
-    """Evaluate recent PR activity."""
-    # Don't need to analyze PR activity if fewer than 10 PRs opened recently.
-    if pdata.opened_count < 10:
+    """Evaluate recent PR activity.
+    
+    Only evaluate PR activity against external repos, not PRs against repos
+    the user owns.
+    """
+
+
+
+    # Don't need to analyze PR activity below a small threshold.
+    min_external_pr_threshold = 3
+    if pdata.opened_count < min_external_pr_threshold:
         pdata.flag_merged_pr = flags.green_flag
         pdata.flag_closed_pr = flags.green_flag
+
+        if pdata.verbose:
+            msg = f"PR flags set green because fewer than {min_external_pr_threshold} PRs opened against external repos."
+            print(msg)
+            
         return
 
-    ratio_merged = pdata.merged_count / pdata.opened_count
-    ratio_closed = pdata.closed_count / pdata.opened_count
+    ratio_merged = pdata.merged_count_external / pdata.opened_count_external
+    ratio_closed = pdata.closed_count_external / pdata.opened_count_external
 
     if ratio_closed > 0.5:
         pdata.flag_closed_pr = flags.red_flag

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -73,9 +73,6 @@ def _process_pr_activity():
     Only evaluate PR activity against external repos, not PRs against repos
     the user owns.
     """
-
-
-
     # Don't need to analyze PR activity below a small threshold.
     min_external_pr_threshold = 3
     if pdata.opened_count < min_external_pr_threshold:
@@ -85,7 +82,14 @@ def _process_pr_activity():
         if pdata.verbose:
             msg = f"PR flags set green because fewer than {min_external_pr_threshold} PRs opened against external repos."
             print(msg)
-            
+
+        return
+
+    # All the following analysis focuses on PRs against external repos.
+    if pdata.opened_count_external == 0:
+        # DEV: Do these need to be set?
+        pdata.flag_merged_pr = flags.green_flag
+        pdata.flag_closed_pr = flags.green_flag
         return
 
     ratio_merged = pdata.merged_count_external / pdata.opened_count_external

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -38,10 +38,19 @@ class ProfileData:
     flag_profile: str = ""
 
     # --- PR fields ---
+    # These fields are broken into PRs against repos you own, and PRs against
+    # external repos.
     opened_count: int = 0
-    merged_count: int = 0
-    closed_count: int = 0
+    opened_count_owned: int = 0
+    opened_count_external: int = 0
 
+    merged_count_owned: int = 0
+    merged_count_external: int = 0
+
+    closed_count_owned: int = 0
+    closed_count_external: int = 0
+
+    # No flags needed for PRs against your own repos; that's informational only.
     flag_merged_pr: str = ""
     flag_closed_pr: str = ""
 

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -147,6 +147,7 @@ def _parse_pr_activity(pr_activity_str):
         msg += "\n  You may want to try running the command again."
         sys.exit(msg)
 
+    breakpoint()
     search = data["data"]["search"]
     prs = search["nodes"]
 
@@ -211,21 +212,27 @@ def _get_pr_query():
             search(query: $q, type: ISSUE, first: $n) {{
                 issueCount
                 pageInfo {{
-                hasNextPage
-                endCursor
+                    hasNextPage
+                    endCursor
                 }}
                 nodes {{
-                ... on PullRequest {{
-                    number
-                    state
-                    createdAt
-                    closedAt
-                    mergedAt
-                    url
-                }}
+                    ... on PullRequest {{
+                        number
+                        state
+                        createdAt
+                        closedAt
+                        mergedAt
+                        url
+                        repository {{
+                            nameWithOwner
+                            owner {{
+                                login
+                            }}
+                        }}
+                    }}
                 }}
             }}
-            }}
+        }}
     """
 
     return dedent(pr_query).strip()

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -147,16 +147,35 @@ def _parse_pr_activity(pr_activity_str):
         msg += "\n  You may want to try running the command again."
         sys.exit(msg)
 
-    breakpoint()
     search = data["data"]["search"]
     prs = search["nodes"]
 
     pdata.opened_count = len(prs)
-    pdata.merged_count = sum(pr["mergedAt"] is not None for pr in prs)
-    pdata.closed_count = sum(
-        pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs
+
+    # PRs against repos the user owns.
+    prs_owned = [
+        pr for pr in prs
+        if pr["repository"]["owner"]["login"].casefold()
+        == pdata.username.casefold()
+    ]
+
+    pdata.opened_count_owned = len(prs_owned)
+    pdata.merged_count_owned = sum(pr["mergedAt"] is not None for pr in prs_owned)
+    pdata.closed_count_owned = sum(
+        pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_owned
     )
 
+    # PRs against external repos.
+    prs_external = [
+        pr for pr in prs
+        if pr["repository"]["owner"]["login"].casefold()
+        != pdata.username.casefold()
+    ]
+    pdata.opened_count_external = len(prs_external)
+    pdata.merged_count_external = sum(pr["mergedAt"] is not None for pr in prs_external)
+    pdata.closed_count_external = sum(
+        pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_external
+    )
 
 def _fetch_issue_activity():
     """Fetch target user's recent public issue activity."""

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -182,10 +182,16 @@ def _bio_summary(bio):
 
 def _pr_activity_summary():
     """Summarize recent PR activity."""
-    if pdata.opened_count < 10:
-        return f"   {flags.green_flag} Fewer than 10 PRs opened in the last 21 days.\n"
+    if pdata.opened_count == 0:
+        return f"   {flags.green_flag} No PRs opened in the last 21 days.\n"
 
     summary = ""
+
+    if pdata.opened_count == 1:
+        summary += "   1 PR opened in the last 21 days.\n"
+    else:
+        summary += f"   {pdata.opened_count} PRs opened in the last 21 days.\n"
+
     # Only show merged if it's a good sign.
     if pdata.flag_merged_pr == flags.green_flag:
         summary += f"   {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs merged in the last 21 days.\n"

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -194,8 +194,8 @@ def _pr_activity_summary():
         summary += f"   {pdata.opened_count} PRs opened in the last 21 days.\n"
 
     # Report breakdown of owned and external PRs.
-    summary += f"   {pdata.opened_count_owned} opened against repos the user owns.\n"
-    summary += f"   {pdata.opened_count_external} opened against external repos.\n\n"
+    summary += f"      {pdata.opened_count_owned} opened against repos the user owns.\n"
+    summary += f"      {pdata.opened_count_external} opened against external repos.\n\n"
 
     # If no external PRs, there's nothing more to add.
     if pdata.opened_count_external == 0:

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -187,17 +187,26 @@ def _pr_activity_summary():
 
     summary = ""
 
+    # Report overall PR activity, including PRs against owned and external repos.
     if pdata.opened_count == 1:
         summary += "   1 PR opened in the last 21 days.\n"
     else:
         summary += f"   {pdata.opened_count} PRs opened in the last 21 days.\n"
 
+    # Report breakdown of owned and external PRs.
+    summary += f"   {pdata.opened_count_owned} opened against repos the user owns.\n"
+    summary += f"   {pdata.opened_count_external} opened against external repos.\n\n"
+
+    # If no external PRs, there's nothing more to add.
+    if pdata.opened_count_external == 0:
+        return summary
+
     # Only show merged if it's a good sign.
     if pdata.flag_merged_pr == flags.green_flag:
-        summary += f"   {pdata.flag_merged_pr} {pdata.merged_count} of {pdata.opened_count} PRs merged in the last 21 days.\n"
+        summary += f"   {pdata.flag_merged_pr} {pdata.merged_count_external} of {pdata.opened_count_external} external PRs merged in the last 21 days.\n"
 
     # Include number closed for everyone.
-    summary += f"   {pdata.flag_closed_pr} {pdata.closed_count} of {pdata.opened_count} PRs closed without merging in the last 21 days.\n"
+    summary += f"   {pdata.flag_closed_pr} {pdata.closed_count_external} of {pdata.opened_count_external} external PRs closed without merging in the last 21 days.\n"
 
     return summary
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -40,6 +40,8 @@ def filled_pdata():
 
     pdata.flag_age = flags.green_flag
     pdata.flag_profile = flags.green_flag
+    pdata.flag_merged_pr = flags.green_flag
+    pdata.flag_closed_pr = flags.green_flag
 
     # This is taken from analysis_utils.py:
     fields = ["name", "company", "blog", "location", "email", "bio"]

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -33,8 +33,10 @@ def filled_pdata():
     pdata.account_age = timedelta(days=5058)
 
     pdata.opened_count = 5
-    pdata.closed_count = 1
-    pdata.merged_count = 3
+    pdata.opened_count_owned = 0
+    pdata.opened_count_external = 5
+    pdata.closed_count_external = 1
+    pdata.merged_count_external = 3
 
     pdata.flag_age = flags.green_flag
     pdata.flag_profile = flags.green_flag

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -12,7 +12,12 @@ GitHub user: ehmatthes
       Empty fields: company, bio
 
 🟢 No concerns found with recent PR activity.
-   🟢 Fewer than 10 PRs opened in the last 21 days.
+   5 PRs opened in the last 21 days.
+      0 opened against repos the user owns.
+      5 opened against external repos.
+
+   🟢 3 of 5 external PRs merged in the last 21 days.
+   🟢 1 of 5 external PRs closed without merging in the last 21 days.
 
 🟢 No concerns found with recent issue activity.
    🟢 7 new issues opened in the last 21 days.


### PR DESCRIPTION
There's a significant difference between opening PRs on your own repos, vs PRs opened against repos that belong to others. It's really the second kind that matter.

Reports overall number of PRs opened, and breakdown of owned vs external PRs. Analysis is done against PRs opened against external repos.

This means someone merging a bunch of PRs against their own repos doesn't mask poor contributions to external repos.

See #100.