### PR TITLE
Check stderr for authentication status before concluding the user is not authenticated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### 0.6.6
+
+#### External changes
+
+- Users who are not authenticated on one account but are authenticated on another account should be able to run gh-profiler without running into an authentication failure issue.
+
+#### Internal changes
+
+- The `run_cmd()` utility returns a `CommandResult` instance instead of just stdout. The result instance has `stdout`, `stderr`, and `returncode` fields.
+- If the auth check does not pass when looking at stdout, it looks at stderr. If the "Logged in to GitHub" message is in either of those, execution proceeds.
+
 ### 0.6.5
 
 #### External changes

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -69,7 +69,8 @@ def run_with_timeout(cmd):
     num_attempts = 0
     while num_attempts < 5:
         try:
-            output = infra_utils.run_cmd(cmd, timeout=5)
+            result = infra_utils.run_cmd(cmd, timeout=5)
+            output = result.stdout
         except subprocess.TimeoutExpired:
             print("Time out.")
             num_attempts += 1

--- a/src/gh_profiler/utils/cli_utils.py
+++ b/src/gh_profiler/utils/cli_utils.py
@@ -27,14 +27,14 @@ def process_pr_issue_num(pr_issue_num):
 
 def _get_repo_slug():
     """Ask `gh` for the resolved default repo (honors `gh repo set-default`)."""
-    slug = run_cmd("gh repo view --json nameWithOwner --jq .nameWithOwner").strip()
-    if not slug:
+    result = run_cmd("gh repo view --json nameWithOwner --jq .nameWithOwner").strip()
+    if not result.stdout:
         msg = (
             "Couldn't determine the default GitHub repository. "
             "Run `gh repo set-default` in this directory and try again."
         )
         sys.exit(msg)
-    return slug
+    return result.stdout
 
 
 def _process_pr(pr_issue_num, repo_slug):
@@ -42,8 +42,8 @@ def _process_pr(pr_issue_num, repo_slug):
     # pr_cmd = f'gh pr view {pr_issue_num} --repo {repo_slug} --json author --jq ".author.login"'
     pr_cmd = f"gh pr view {pr_issue_num} --repo {repo_slug} --json author --json title"
     try:
-        results = run_cmd(pr_cmd)
-        results_json = json.loads(results)
+        result = run_cmd(pr_cmd)
+        results_json = json.loads(result.stdout)
 
         pdata.is_pr = True
         pdata.pr_number = pr_issue_num
@@ -61,8 +61,8 @@ def _process_issue(pr_issue_num, repo_slug):
         f"gh issue view {pr_issue_num} --repo {repo_slug} --json author --json title"
     )
     try:
-        results = run_cmd(issue_cmd)
-        results_json = json.loads(results)
+        result = run_cmd(issue_cmd)
+        results_json = json.loads(result.stdout)
 
         pdata.is_issue = True
         pdata.issue_number = pr_issue_num

--- a/src/gh_profiler/utils/infra_utils.py
+++ b/src/gh_profiler/utils/infra_utils.py
@@ -3,6 +3,8 @@
 import os
 import shlex
 import subprocess
+from dataclasses import dataclass
+
 
 DEFAULT_ENV = {
     **os.environ,
@@ -10,9 +12,21 @@ DEFAULT_ENV = {
     "NO_COLOR": "1",
 }
 
+@dataclass
+class CommandResult:
+    """Decoded subprocess output."""
+    stdout: str
+    stderr: str
+    returncode: int
+
 
 def run_cmd(cmd, env=DEFAULT_ENV, timeout=None):
-    """Run a subprocess command, return stdout."""
+    """Run a subprocess command, return CommandResult instance."""
     cmd_parts = shlex.split(cmd)
     output_obj = subprocess.run(cmd_parts, capture_output=True, env=env, timeout=timeout)
-    return output_obj.stdout.decode()
+
+    return CommandResult(
+        stdout=output_obj.stdout.decode(),
+        stderr=output_obj.stderr.decode(),
+        returncode=output_obj.returncode,
+    )

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -21,7 +21,8 @@ def ensure_gh():
     """
     cmd = "gh --version"
     try:
-        version_info = infra_utils.run_cmd(cmd)
+        result = infra_utils.run_cmd(cmd)
+        version_info = result.stdout
     except FileNotFoundError:
         msg = "The GitHub CLI tool (gh) must be installed."
         msg += "\n  https://cli.github.com"
@@ -70,7 +71,9 @@ def get_data():
 def _fetch_status():
     """Fetch output of `gh auth status`."""
     cmd = "gh auth status"
-    return infra_utils.run_cmd(cmd)
+    result = infra_utils.run_cmd(cmd)
+
+    return result.stdout
 
 def _parse_status(status_str):
     """Parse output of status call."""
@@ -89,7 +92,9 @@ def _parse_status(status_str):
 def _fetch_profile_dict():
     """Fetch the profile information we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
-    return infra_utils.run_cmd(cmd)
+    result = infra_utils.run_cmd(cmd)
+
+    return result.stdout
 
 def _parse_profile_dict(profile_dict_str):
     """Parse the profile information that was fetched."""
@@ -115,7 +120,9 @@ def _fetch_socials():
     they require an additional API call.
     """
     cmd = f"gh api users/{pdata.username}/social_accounts"
-    return infra_utils.run_cmd(cmd)
+    result = infra_utils.run_cmd(cmd)
+
+    return result.stdout
 
 def _parse_socials(socials_str):
     """Parse the data string returned from _fetch_socials()."""
@@ -136,7 +143,9 @@ def _fetch_pr_activity():
         f"author:{pdata.username} is:pull-request is:public created:>={cutoff}"
     )
     cmd = f"gh api graphql -f query='{pr_query}' -F q='{search_query}' -F n=100"
-    return infra_utils.run_cmd(cmd)
+    result = infra_utils.run_cmd(cmd)
+
+    return result.stdout
 
 def _parse_pr_activity(pr_activity_str):
     """Parse the data returned by _fetch_pr_activity()."""
@@ -181,7 +190,9 @@ def _fetch_issue_activity():
     """Fetch target user's recent public issue activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
     gh_call = _get_gh_issues_call(pdata.username, cutoff)
-    return infra_utils.run_cmd(gh_call)
+    result = infra_utils.run_cmd(gh_call)
+
+    return result.stdout
 
 def _parse_issue_activity(issue_activity_str):
     """Parse data returned by _fetch_issue_activity()."""

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -48,7 +48,7 @@ def get_data():
         issue_activity_future = executor.submit(_fetch_issue_activity)
 
         # When each call finishes, store the result.
-        status_str = status_future.result()
+        status_obj = status_future.result()
         profile_dict_str = profile_dict_future.result()
         socials_str = socials_future.result()
         pr_activity_str = pr_activity_future.result()
@@ -59,7 +59,7 @@ def get_data():
         print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
 
     # Parse data. This should only happen after all data has been fetched.
-    _parse_status(status_str)
+    _parse_status(status_obj)
     _parse_profile_dict(profile_dict_str)
     _parse_socials(socials_str)
     _parse_pr_activity(pr_activity_str)
@@ -69,23 +69,35 @@ def get_data():
 # --- Helper functions ---
 
 def _fetch_status():
-    """Fetch output of `gh auth status`."""
+    """Fetch output of `gh auth status`.
+    
+    Unlike most other calls, this returns the CommandResult instance, because
+    we'll need to inspect stdout and stderr.
+    """
     cmd = "gh auth status"
-    result = infra_utils.run_cmd(cmd)
+    return infra_utils.run_cmd(cmd)
 
-    return result.stdout
-
-def _parse_status(status_str):
-    """Parse output of status call."""
-    if "Logged in to github.com account " not in status_str:
-        # Show the stdout part of `gh auth status`, if there is any.
+def _parse_status(status_obj):
+    """Parse output of status call.
+    
+    Unlike most other parsing functions, this acts no an instance of
+    CommandResult, because we need to look at stdout and stderr.
+    """
+    msg_authenticated = "Logged in to github.com account "
+    authenticated = (
+        msg_authenticated in status_obj.stdout
+        or msg_authenticated in status_obj.stderr
+    )
+    if not authenticated:
+        # Show the output of `gh auth status`, if there is any.
         # I believe this is relevant when the user has an expired token.
-        if status_str:
-            msg = f"{status_str}\n"
-        else:
-            msg = ""
+        msg = ""
+        if status_obj.stdout:
+            msg += f"\n{status_obj.stdout}\n"
+        if status_obj.stderr:
+            msg += f"\n{status_obj.stderr}\n"
 
-        msg += "The GitHub CLI tool (gh) is not authenticated."
+        msg += "\nThe GitHub CLI tool (gh) is not authenticated."
         msg += "\nRun `gh auth login` to authenticate."
         sys.exit(msg)
 

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -20,7 +20,8 @@ def run_with_timeout(cmd):
     num_attempts = 0
     while num_attempts < 5:
         try:
-            output = infra_utils.run_cmd(cmd, timeout=5)
+            result = infra_utils.run_cmd(cmd, timeout=5)
+            output = result.stdout
         except subprocess.TimeoutExpired:
             print("Time out.")
             num_attempts += 1


### PR DESCRIPTION
Fixes #106. Also, updates `run_cmd()` to return an instance of `CommandResult`, so that the auth status check can examine both stdout and stderr when it needs to.