### PR TITLE
Adjust thresholds for PR activity volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### Unreleased
+
+#### External changes
+
+- Bumped PR activity thresholds slightly, so extremely low volume PR activity does not trip flags. ie, having one or two PRs closed does not raise any flags, even though the ratio of closed to opened might be above the threshold.
+- Also fixes unreported bug where overall number of PRs opened was being checked against external PR threshold.
+
+#### Internal changes
+
+- NA
+
 ### 0.6.6
 
 #### External changes

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -74,7 +74,7 @@ def _process_pr_activity():
     the user owns.
     """
     # Don't need to analyze PR activity below a small threshold.
-    min_external_pr_threshold = 3
+    min_external_pr_threshold = 4
     if pdata.opened_count < min_external_pr_threshold:
         pdata.flag_merged_pr = flags.green_flag
         pdata.flag_closed_pr = flags.green_flag
@@ -96,8 +96,11 @@ def _process_pr_activity():
     ratio_closed = pdata.closed_count_external / pdata.opened_count_external
 
     if ratio_closed > 0.5:
+        # The lowest threshold would be 2 out of 4 PRs closed, which might be
+        # too low but is reasonable to start with.
         pdata.flag_closed_pr = flags.red_flag
-    elif ratio_closed > 0.15:
+    elif ratio_closed > 0.2 and pdata.closed_count_external > 2:
+        # Don't set this flag if the total closed count is 2 or fewer.
         pdata.flag_closed_pr = flags.yellow_flag
     else:
         pdata.flag_closed_pr = flags.green_flag

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -75,7 +75,7 @@ def _process_pr_activity():
     """
     # Don't need to analyze PR activity below a small threshold.
     min_external_pr_threshold = 4
-    if pdata.opened_count < min_external_pr_threshold:
+    if pdata.opened_count_external < min_external_pr_threshold:
         pdata.flag_merged_pr = flags.green_flag
         pdata.flag_closed_pr = flags.green_flag
 

--- a/tests/unit_tests/test_flag_evaluations.py
+++ b/tests/unit_tests/test_flag_evaluations.py
@@ -1,0 +1,29 @@
+"""Tests for whether the correct flags are assigned, based on what's found."""
+
+from gh_profiler.utils import analysis_utils
+from gh_profiler.utils import summary_utils
+from gh_profiler.utils.profile_data import profile_data as pdata
+from gh_profiler.utils import flags
+from reference_files import reference_summaries
+
+
+
+def test_low_pr_volume_one_external_pr_closed():
+    """Test that an external PR being closed doesn't result in a yellow or red
+    flag when there's low overall PR volume.
+    """
+    # Set relevant user data.
+    pdata.opened_count = 3
+    pdata.opened_count_owned = 0
+    pdata.opened_count_external = 3
+
+    pdata.merged_count_external = 2
+    pdata.closed_count_external = 1
+
+    # Just run the PR activity analysis.
+    analysis_utils._process_pr_activity()
+
+    summary = summary_utils._get_summary()
+
+    assert flags.yellow_flag not in summary
+    assert flags.red_flag not in summary


### PR DESCRIPTION
I noticed a well-trusted maintainer had yellow flags. It turns out that was because they had just a handful of external PRs, and one was closed without merging. The low volume meant 1/x was a high ratio. Bumped these thresholds up to avoid this kind of situation.

These may need to be raised a little higher, hopefully that comes up after all these thresholds are in a central config object.

Also fixes unreported bug where overall number of PRs opened was being checked against external PR threshold.
