### PR TITLE
Don't count activity against repositories and orgs you own

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 
 # Used for cProfile output.
 profile.txt
+
+sandbox/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### 0.7.0
+
+#### External changes
+
+- Identifies PRs and issues in three categories: against repos the user owns, against orgs the user is publicly associated with, and against external orgs. All analysis for evaluating flags is based on the user's activity in external repos.
+- Reports orgs the user is publicly associated with.
+
+#### Internal changes
+
+- Ensure no doubled blank lines in summary.
+- More consistent separation of fetching, parsing, and evaluating user activity data.
+
 ### 0.6.7
 
 #### External changes

--- a/README.md
+++ b/README.md
@@ -26,15 +26,20 @@ GitHub user: <redacted>
 🟢 No concerns found with recent PR activity.
    2 PRs opened in the last 21 days.
       0 opened against repos the user owns.
+      0 opened against repos in publicly associated orgs.
       2 opened against external repos.
 
    🟢 1 of 2 external PRs merged in the last 21 days.
    🟢 1 of 2 external PRs closed without merging in the last 21 days.
 
 🔴 Significant concerns found with recent issue activity.
-   🔴 79 new issues opened in the last 21 days.
-   🟢 1 issues closed as NOT_PLANNED.
-   🔴 70 issues opened with the same title:
+   79 new issues opened in the last 21 days.
+      0 opened in repos the user owns.
+      0 opened in repos in publicly associated orgs.
+      79 opened in external repos.
+
+   🟢 1 external issue closed as NOT_PLANNED.
+   🔴 78 external issues opened with the same title:
         📋 Documentation Enhancement Suggestion (70)
 ```
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ $ uv run developer_resources/benchmark.py
 $ uv run developer_resources/benchmark.py <target>
 ```
 
+Benchmarking is pretty straightforward when:
+
+- Using `git switch` to switch between main and dev branches;
+- Using Git to check out different tags and commits.
+- Using `uv run --python 3.14`, `uv run --python 3.14t`, etc.
+
 New releases
 ---
 

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -111,10 +111,6 @@ def _process_pr_activity():
 
 def _process_issue_activity():
     """Evaluate recent public issue activity."""
-    # How many new issues have been opened recently?
-    pdata.new_issue_count = pdata.issue_activity["issueCount"]
-
-    # How many have been closed with a problematic state?
     _process_issue_state()
     _process_repeated_issues()
 

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime as dt, timezone
 from datetime import timezone as tz
-from collections import Counter
 
 from .profile_data import profile_data as pdata
 from . import flags
@@ -124,18 +123,7 @@ def _process_issue_activity():
 
 
 def _process_issue_state():
-    """Examine state of closed issues.
-
-    Mostly looking for statuses like "NOT_PLANNED".
-    The GraphQL endpoint
-    """
-    issue_dicts = pdata.issue_activity["nodes"]
-
-    # How many issues were closed as NOT_PLANNED?
-    pdata.issues_not_planned = len(
-        [d for d in issue_dicts if d["stateReason"] == "NOT_PLANNED"]
-    )
-
+    """Examine state of closed issues."""
     # Green flag
     if pdata.issues_not_planned <= 3:
         flag = flags.green_flag
@@ -148,16 +136,6 @@ def _process_issue_state():
 
 def _process_repeated_issues():
     """Look for spamming the same issue to multiple repositories."""
-    issue_dicts = pdata.issue_activity["nodes"]
-    issue_titles = [d["title"].strip() for d in issue_dicts]
-
-    counter = Counter(issue_titles)
-    # Only keep titles for repeated issues.
-    pdata.repeated_issue_titles = {
-        title: count for title, count in counter.items() if count > 1
-    }
-    pdata.total_repeats = sum(pdata.repeated_issue_titles.values())
-
     # There are some valid reasons for someone to open the same issue across
     # several repositories. For example if they open it on the wrong issue,
     # close it, then open it on the correct repo, that's two identical issues.

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -43,6 +43,7 @@ class ProfileData:
     # external repos.
     opened_count: int = 0
     opened_count_owned: int = 0
+    opened_count_orgs: int = 0
     opened_count_external: int = 0
 
     merged_count_owned: int = 0

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -58,6 +58,11 @@ class ProfileData:
 
     # --- Issue fields ---
     new_issue_count: int = 0
+    issues_owned: int = 0
+    issues_orgs: int = 0
+    issues_external: int = 0
+
+    # These fields all relate to external issues.
     issues_not_planned: int = 0
     total_repeats: int = 0
     repeated_issue_titles: dict | None = None

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -32,6 +32,7 @@ class ProfileData:
     profile_info: dict | None = None
 
     account_age: int = 0
+    orgs: list | None = None
     socials: list | None = None
 
     flag_age: str = ""

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -46,10 +46,7 @@ class ProfileData:
     opened_count_orgs: int = 0
     opened_count_external: int = 0
 
-    merged_count_owned: int = 0
     merged_count_external: int = 0
-
-    closed_count_owned: int = 0
     closed_count_external: int = 0
 
     # No flags needed for PRs against your own repos; that's informational only.

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -210,10 +210,6 @@ def _parse_pr_activity(pr_activity_str):
     ]
 
     pdata.opened_count_owned = len(prs_owned)
-    pdata.merged_count_owned = sum(pr["mergedAt"] is not None for pr in prs_owned)
-    pdata.closed_count_owned = sum(
-        pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_owned
-    )
 
     # PRS against repos in orgs the user is publicly associated with.
     prs_orgs = [

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -273,6 +273,10 @@ def _get_gh_issues_call(username, cutoff):
                 url
                 repository {{
                 nameWithOwner
+                isInOrganization
+                owner {{
+                    __typename
+                    login
                 }}
             }}
             }}

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from datetime import timezone as tz
 from textwrap import dedent
 from time import perf_counter
+from collections import Counter
 
 from . import infra_utils
 from .profile_data import profile_data as pdata
@@ -251,7 +252,38 @@ def _parse_issue_activity(issue_activity_str):
         msg += "\n  You may want to try running the command again."
         sys.exit(msg)
 
-    breakpoint()
+    issue_dicts = pdata.issue_activity["nodes"]
+    issues_owned = [
+        id for id in issue_dicts
+        if id["repository"]["owner"]["login"] == pdata.username
+    ]
+    issues_orgs = [
+         id for id in issue_dicts
+         if id["repository"]["owner"]["login"] in pdata.orgs
+    ]
+    issues_external = [
+         id for id in issue_dicts
+         if id not in issues_owned
+         and id not in issues_orgs
+    ]
+
+    pdata.issues_external = len(issues_external)
+    pdata.issues_not_planned = len(
+        [d for d in issues_external if d["stateReason"] == "NOT_PLANNED"]
+    )
+
+    _process_repeated_issues(issues_external)
+
+def _process_repeated_issues(issues_external):
+    """Look for issues with the same title across multiple repositories."""
+    issue_titles = [d["title"].strip() for d in issues_external]
+
+    counter = Counter(issue_titles)
+    # Only keep titles for repeated issues.
+    pdata.repeated_issue_titles = {
+        title: count for title, count in counter.items() if count > 1
+    }
+    pdata.total_repeats = sum(pdata.repeated_issue_titles.values())
 
 
 def _get_gh_issues_call(username, cutoff):

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -43,6 +43,7 @@ def get_data():
         # Make fetching calls.
         status_future = executor.submit(_fetch_status)
         profile_dict_future = executor.submit(_fetch_profile_dict)
+        orgs_future = executor.submit(_fetch_orgs)
         socials_future = executor.submit(_fetch_socials)
         pr_activity_future = executor.submit(_fetch_pr_activity)
         issue_activity_future = executor.submit(_fetch_issue_activity)
@@ -50,6 +51,7 @@ def get_data():
         # When each call finishes, store the result.
         status_obj = status_future.result()
         profile_dict_str = profile_dict_future.result()
+        orgs_str = orgs_future.result()
         socials_str = socials_future.result()
         pr_activity_str = pr_activity_future.result()
         issue_activity_str = issue_activity_future.result()
@@ -61,6 +63,7 @@ def get_data():
     # Parse data. This should only happen after all data has been fetched.
     _parse_status(status_obj)
     _parse_profile_dict(profile_dict_str)
+    _parse_orgs(orgs_str)
     _parse_socials(socials_str)
     _parse_pr_activity(pr_activity_str)
     _parse_issue_activity(issue_activity_str)
@@ -124,6 +127,31 @@ def _parse_profile_dict(profile_dict_str):
     # but every value is None.
     if pdata.profile_dict["created_at"] is None:
         sys.exit(f"GitHub user '{pdata.username}' not found.")
+
+def _fetch_orgs():
+    """Fetch the user's publicly visible orgs.
+    
+    This will be used to distinguish between PRs and issues opened against
+    external repos, and repos the user is associated with.
+    """
+    cmd = (
+        f"gh api users/{pdata.username}/orgs "
+        "--jq '[.[] | {login, description, url}]'"
+    )
+    result = infra_utils.run_cmd(cmd)
+
+    return result.stdout
+
+def _parse_orgs(orgs_str):
+    """Parse the org info that was found."""
+    try:
+        orgs = json.loads(orgs_str)
+    except json.decoder.JSONDecodeError:
+        msg = "Couldn't get org info. The gh CLI may have timed out."
+        msg += "\n  You may want to try running the command again."
+        sys.exit(msg)
+
+    pdata.orgs = [org["login"] for org in orgs]
 
 def _fetch_socials():
     """Fetch social media accounts from user's profile.

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -242,13 +242,13 @@ def _fetch_issue_activity():
 def _parse_issue_activity(issue_activity_str):
     """Parse data returned by _fetch_issue_activity()."""
     try:
-        pdata.issue_activity = json.loads(issue_activity_str)["data"]["search"]
+        issue_activity = json.loads(issue_activity_str)["data"]["search"]
     except (json.decoder.JSONDecodeError, KeyError):
         msg = "Couldn't get recent issue activity. The gh CLI may have timed out."
         msg += "\n  You may want to try running the command again."
         sys.exit(msg)
 
-    issue_dicts = pdata.issue_activity["nodes"]
+    issue_dicts = issue_activity["nodes"]
     issues_owned = [
         id for id in issue_dicts
         if id["repository"]["owner"]["login"] == pdata.username
@@ -262,6 +262,10 @@ def _parse_issue_activity(issue_activity_str):
          if id not in issues_owned
          and id not in issues_orgs
     ]
+
+    # DEV: Should we be dealing with pagination?
+    # When does issueCount != len(issue_dicts)?
+    pdata.new_issue_count = issue_activity["issueCount"]
 
     pdata.issues_owned = len(issues_owned)
     pdata.issues_orgs = len(issues_orgs)

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -225,7 +225,6 @@ def _parse_pr_activity(pr_activity_str):
     pdata.closed_count_external = sum(
         pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_external
     )
-    breakpoint()
 
 def _fetch_issue_activity():
     """Fetch target user's recent public issue activity."""

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -197,6 +197,7 @@ def _parse_pr_activity(pr_activity_str):
     pdata.closed_count_external = sum(
         pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_external
     )
+    breakpoint()
 
 def _fetch_issue_activity():
     """Fetch target user's recent public issue activity."""
@@ -267,7 +268,9 @@ def _get_pr_query():
                         url
                         repository {{
                             nameWithOwner
+                            isInOrganization
                             owner {{
+                                __typename
                                 login
                             }}
                         }}

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -208,6 +208,12 @@ def _parse_pr_activity(pr_activity_str):
         == pdata.username.casefold()
     ]
 
+    # PRS against repos in orgs the user is publicly associated with.
+    prs_orgs = [
+        pr for pr in prs
+        if pr["repository"]["owner"]["login"] in pdata.orgs
+    ]
+
     pdata.opened_count_owned = len(prs_owned)
     pdata.merged_count_owned = sum(pr["mergedAt"] is not None for pr in prs_owned)
     pdata.closed_count_owned = sum(
@@ -217,8 +223,8 @@ def _parse_pr_activity(pr_activity_str):
     # PRs against external repos.
     prs_external = [
         pr for pr in prs
-        if pr["repository"]["owner"]["login"].casefold()
-        != pdata.username.casefold()
+        if pr not in prs_owned
+        and pr not in prs_orgs
     ]
     pdata.opened_count_external = len(prs_external)
     pdata.merged_count_external = sum(pr["mergedAt"] is not None for pr in prs_external)

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -208,17 +208,19 @@ def _parse_pr_activity(pr_activity_str):
         == pdata.username.casefold()
     ]
 
+    pdata.opened_count_owned = len(prs_owned)
+    pdata.merged_count_owned = sum(pr["mergedAt"] is not None for pr in prs_owned)
+    pdata.closed_count_owned = sum(
+        pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_owned
+    )
+
     # PRS against repos in orgs the user is publicly associated with.
     prs_orgs = [
         pr for pr in prs
         if pr["repository"]["owner"]["login"] in pdata.orgs
     ]
 
-    pdata.opened_count_owned = len(prs_owned)
-    pdata.merged_count_owned = sum(pr["mergedAt"] is not None for pr in prs_owned)
-    pdata.closed_count_owned = sum(
-        pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_owned
-    )
+    pdata.opened_count_orgs = len(prs_orgs)
 
     # PRs against external repos.
     prs_external = [

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -267,6 +267,8 @@ def _parse_issue_activity(issue_activity_str):
          and id not in issues_orgs
     ]
 
+    pdata.issues_owned = len(issues_owned)
+    pdata.issues_orgs = len(issues_orgs)
     pdata.issues_external = len(issues_external)
     pdata.issues_not_planned = len(
         [d for d in issues_external if d["stateReason"] == "NOT_PLANNED"]

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -251,6 +251,8 @@ def _parse_issue_activity(issue_activity_str):
         msg += "\n  You may want to try running the command again."
         sys.exit(msg)
 
+    breakpoint()
+
 
 def _get_gh_issues_call(username, cutoff):
     """Return the gh call for recent public issue activity."""
@@ -277,6 +279,7 @@ def _get_gh_issues_call(username, cutoff):
                 owner {{
                     __typename
                     login
+                }}
                 }}
             }}
             }}

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -185,7 +185,7 @@ def _bio_summary(bio):
 def _org_summary():
     """Summarize user's orgs."""
     if not pdata.orgs:
-        return
+        return ""
     
     orgs_list = ", ".join(pdata.orgs)
     return f"      Orgs: {orgs_list}\n"

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -241,6 +241,6 @@ def _issue_activity_summary():
     else:
         summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} external issues opened with the same title:\n"
     for title, count in pdata.repeated_issue_titles.items():
-        summary += f"      {title} ({count})\n"
+        summary += f"        {title} ({count})\n"
 
     return summary

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -92,11 +92,13 @@ def _get_full_summary():
     summary += _get_issue_header()
     summary += _issue_activity_summary()
 
+    # Make sure there are no doubled blank lines in summary.
+    summary = summary.replace("\n\n\n", "\n\n")
+
     return summary.strip()
 
 
 # --- Helper functions ---
-
 
 def _redact_info():
     """Redact identifying information when --redact passed.
@@ -166,7 +168,6 @@ def _profile_summary():
         summary += f"      Empty fields: {fields_str}\n"
 
     return summary
-
 
 def _bio_summary(bio):
     """Summarize bio section of profile."""

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -81,6 +81,7 @@ def _get_full_summary():
     age = humanize.naturaldelta(pdata.account_age)
     summary += f"   {pdata.flag_age} Account age: {age}"
     summary += _profile_summary()
+    summary += _org_summary()
     summary += "\n"
 
     # Include PR activity.
@@ -179,6 +180,15 @@ def _bio_summary(bio):
     for line in bio.splitlines():
         summary += f"          {line}\n"
     return summary
+
+
+def _org_summary():
+    """Summarize user's orgs."""
+    if not pdata.orgs:
+        return
+    
+    orgs_list = ", ".join(pdata.orgs)
+    return f"      Orgs: {orgs_list}\n"
 
 
 def _pr_activity_summary():

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -228,15 +228,19 @@ def _issue_activity_summary():
     if pdata.new_issue_count == 0:
         return f"   {flags.green_flag} No new issues opened in the last 21 days.\n"
 
-    summary = f"   {pdata.flag_overall_issues} {pdata.new_issue_count} new issues opened in the last 21 days.\n"
-    summary += f"   {pdata.flag_issues_not_planned} {pdata.issues_not_planned} issues closed as NOT_PLANNED.\n"
+    summary = f"   {pdata.new_issue_count} new issues opened in the last 21 days.\n"
+    summary += f"      {pdata.issues_owned} opened in repos the user owns.\n"
+    summary += f"      {pdata.issues_orgs} opened in repos in publicly associated orgs.\n"
+    summary += f"      {pdata.issues_external} opened in external repos.\n\n"
+    summary += f"   {pdata.flag_issues_not_planned} {pdata.issues_not_planned} external issues closed as NOT_PLANNED.\n"
 
     # Repeated issues:
     if pdata.total_repeats == 0:
-        summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title.\n"
+        # This block has a period, the else block has a colon for the list of titles that follows.
+        summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} external issues opened with the same title.\n"
     else:
-        summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} issues opened with the same title:\n"
+        summary += f"   {pdata.flag_repeated_issues} {pdata.total_repeats} external issues opened with the same title:\n"
     for title, count in pdata.repeated_issue_titles.items():
-        summary += f"        {title} ({count})\n"
+        summary += f"      {title} ({count})\n"
 
     return summary

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -206,7 +206,7 @@ def _pr_activity_summary():
 
     # Report breakdown of owned and external PRs.
     summary += f"      {pdata.opened_count_owned} opened against repos the user owns.\n"
-    summary += f"      {pdata.opened_count_orgs} opened against repos in orgs the user is publicly associated with.\n"
+    summary += f"      {pdata.opened_count_orgs} opened against repos in publicly associated orgs.\n"
     summary += f"      {pdata.opened_count_external} opened against external repos.\n\n"
 
     # If no external PRs, there's nothing more to add.

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -206,6 +206,7 @@ def _pr_activity_summary():
 
     # Report breakdown of owned and external PRs.
     summary += f"      {pdata.opened_count_owned} opened against repos the user owns.\n"
+    summary += f"      {pdata.opened_count_orgs} opened against repos in orgs the user is publicly associated with.\n"
     summary += f"      {pdata.opened_count_external} opened against external repos.\n\n"
 
     # If no external PRs, there's nothing more to add.

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -58,6 +58,7 @@ def test_full_run():
         "name: Eric Matthes",
         "mastodon: https://fosstodon.org/@ehmatthes",
         "Empty fields: company, bio",
+        "Orgs: openlearningtools",
     )
 
     for expected_string in expected_strings:

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -58,7 +58,7 @@ def test_full_run():
         "name: Eric Matthes",
         "mastodon: https://fosstodon.org/@ehmatthes",
         "Empty fields: company, bio",
-        "Orgs: openlearningtools",
+        "Orgs: openlearningtools, django-simple-deploy",
     )
 
     for expected_string in expected_strings:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -49,6 +49,9 @@ def filled_pdata():
 
     # Issue fields
     pdata.new_issue_count = 7
+    pdata.issues_owned = 7
+    pdata.issues_orgs = 0
+    pdata.issues_external = 0
     pdata.total_repeats = 0
     pdata.repeated_issue_titles = {}
 

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -14,6 +14,7 @@ GitHub user: ehmatthes
 🟢 No concerns found with recent PR activity.
    5 PRs opened in the last 21 days.
       0 opened against repos the user owns.
+      0 opened against repos in orgs the user is publicly associated with.
       5 opened against external repos.
 
    🟢 3 of 5 external PRs merged in the last 21 days.

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -14,7 +14,7 @@ GitHub user: ehmatthes
 🟢 No concerns found with recent PR activity.
    5 PRs opened in the last 21 days.
       0 opened against repos the user owns.
-      0 opened against repos in orgs the user is publicly associated with.
+      0 opened against repos in publicly associated orgs.
       5 opened against external repos.
 
    🟢 3 of 5 external PRs merged in the last 21 days.

--- a/tests/unit_tests/reference_files/reference_summaries.py
+++ b/tests/unit_tests/reference_files/reference_summaries.py
@@ -21,7 +21,11 @@ GitHub user: ehmatthes
    🟢 1 of 5 external PRs closed without merging in the last 21 days.
 
 🟢 No concerns found with recent issue activity.
-   🟢 7 new issues opened in the last 21 days.
-   🟢 0 issues closed as NOT_PLANNED.
-   🟢 0 issues opened with the same title.
+   7 new issues opened in the last 21 days.
+      7 opened in repos the user owns.
+      0 opened in repos in publicly associated orgs.
+      0 opened in external repos.
+
+   🟢 0 external issues closed as NOT_PLANNED.
+   🟢 0 external issues opened with the same title.
 """.strip()

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -33,6 +33,13 @@ def test_no_issue_activity():
     assert "issues closed as NOT_PLANNED." not in summary
     assert "issues opened with the same title:" not in summary
 
+def test_summary_orgs():
+    """Test that a user's orgs shows up in the summary."""
+    pdata.orgs = ["org_1", "org_2", "org_3"]
+    summary = summary_utils._get_summary()
+
+    assert "Orgs: org_1, org_2, org_3" in summary
+
 
 def test_redact():
     """Test output when pdata.redact is True."""


### PR DESCRIPTION
From changelog:

#### External changes

- Identifies PRs and issues in three categories: against repos the user owns, against orgs the user is publicly associated with, and against external orgs. All analysis for evaluating flags is based on the user's activity in external repos.
- Reports orgs the user is publicly associated with.

#### Internal changes

- Ensure no doubled blank lines in summary.
- More consistent separation of fetching, parsing, and evaluating user activity data.

Addresses #109.