### PR TITLE
Shorten auth message

### DIFF
--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -87,7 +87,7 @@ def _parse_status(status_obj):
     Unlike most other parsing functions, this acts no an instance of
     CommandResult, because we need to look at stdout and stderr.
     """
-    msg_authenticated = "Logged in to github.com account "
+    msg_authenticated = "Logged in to github.com "
     authenticated = (
         msg_authenticated in status_obj.stdout
         or msg_authenticated in status_obj.stderr


### PR DESCRIPTION
When parsing the returned status output, shorten the expected string to `"Logged in to github.com "`, since the windows version of gh emits the string `Logged in to github.com as JeffersGlass...`, omitting the word `"account"` for some reason.

Fixes #117 