### PR TITLE
Redact user's org info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### Unreleased
+
+#### External changes
+
+- 
+
+#### Internal changes
+
+- 
+
 ### 0.7.1
 
 #### External changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ These initial releases have usable behavior, but may have some rough edges for s
 
 #### External changes
 
-- 
+- Redacts user's org info.
 
 #### Internal changes
 

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -116,6 +116,8 @@ def _redact_info():
 
     for social in pdata.socials:
         social["url"] = "<redacted>"
+    
+    pdata.orgs = ["<redacted>"]
 
 
 def _pr_title_line():

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -85,3 +85,29 @@ def test_concise_run():
 
     for expected_string in expected_strings:
         assert expected_string in output
+
+def test_redact():
+    """Test a --redact run of gh-profiler."""
+    cmd = "uv run gh-profiler ehmatthes --redact"
+    output = run_with_timeout(cmd)
+
+    if output == "":
+        msg = "Output was empty, which may indicate a gh timeout rather than a problem with the code."
+        pytest.fail(msg)
+
+    # Make assertions about stable parts of output, not entire output string.
+    redacted_strings = (
+        "ehmatthes",
+        "Eric Matthes",
+        "https://mostlypython.com",
+        "western North Carolina",
+        "gmail.com",
+        "fosstodon",
+        "openlearningtools",
+    )
+
+    for redacted_string in redacted_strings:
+        assert redacted_string not in output
+
+    # Should currently see 7 redacted fields in my output.
+    assert output.count("<redacted>") == 7

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -47,7 +47,7 @@ def test_redact():
     summary = summary_utils._get_summary()
 
     assert "ehmatthes" not in summary
-    assert summary.count("<redacted") == 5
+    assert summary.count("<redacted") == 6
 
 def test_full_concise_header_lines():
     """The full summary should include the same header lines as concise."""


### PR DESCRIPTION
Updates summary workflow to redact user's org info when `--redact` arg is passed.

Fixes #115.