### PR TITLE
Fix broken usage where target is PR or issue number, since 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ These initial releases have usable behavior, but may have some rough edges for s
 #### External changes
 
 - Redacts user's org info.
+- Fixes broken usage against PRs and issue numbers, since 0.6.6.
 
 #### Internal changes
 
-- 
+- When parsing PR and issue numbers, treat `run_cmd()` result as an object, not a string.
+- E2e test for PR and issue number as target.
 
 ### 0.7.1
 

--- a/src/gh_profiler/utils/cli_utils.py
+++ b/src/gh_profiler/utils/cli_utils.py
@@ -27,7 +27,9 @@ def process_pr_issue_num(pr_issue_num):
 
 def _get_repo_slug():
     """Ask `gh` for the resolved default repo (honors `gh repo set-default`)."""
-    result = run_cmd("gh repo view --json nameWithOwner --jq .nameWithOwner").strip()
+    result = run_cmd("gh repo view --json nameWithOwner --jq .nameWithOwner")
+    output = result.stdout.strip()
+    
     if not result.stdout:
         msg = (
             "Couldn't determine the default GitHub repository. "

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -41,7 +41,7 @@ def run_with_timeout(cmd):
 
 # --- Test functions ---
 
-@pytest.mark.parametrize("target", ["ehmatthes", "1", "3"])
+@pytest.mark.parametrize("target", ["ehmatthes", 1, 3])
 def test_full_run(target):
     """Test a standard run of gh-profiler.
     
@@ -59,14 +59,18 @@ def test_full_run(target):
 
     # Make assertions about stable parts of output, not entire output string.
     # DEV: Find some assertions to make about PRs and issues?
-    expected_strings = (
-        "GitHub user: ehmatthes",
+    if target == "ehmatthes":
+        expected_strings = ["GitHub user: ehmatthes"]
+    else:
+        expected_strings = ["Author: ehmatthes"]
+
+    expected_strings += [
         "🟢 Profile information:",
         "name: Eric Matthes",
         "mastodon: https://fosstodon.org/@ehmatthes",
         "Empty fields: company, bio",
         "Orgs: openlearningtools, django-simple-deploy",
-    )
+    ]
 
     for expected_string in expected_strings:
         assert expected_string in output

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -41,9 +41,16 @@ def run_with_timeout(cmd):
 
 # --- Test functions ---
 
-def test_full_run():
-    """Test a standard run of gh-profiler."""
-    cmd = "uv run gh-profiler ehmatthes"
+@pytest.mark.parametrize("target", ["ehmatthes", "1", "3"])
+def test_full_run(target):
+    """Test a standard run of gh-profiler.
+    
+    Parametrization tests the three main usages:
+    - target is a GitHub username
+    - target is an issue number (1)
+    - target is a PR number (3)
+    """
+    cmd = f"uv run gh-profiler {target}"
     output = run_with_timeout(cmd)
 
     if output == "":


### PR DESCRIPTION
- When parsing PR and issue numbers, treat `run_cmd()` result as an object, not a string.
- E2e test for PR and issue number as target.

Fixes #121.