### PR TITLE
Support bulk profiling of recently opened PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ These initial releases have usable behavior, but may have some rough edges for s
 
 - Redacts user's org info.
 - Fixes broken usage against PRs and issue numbers, since 0.6.6.
+- Supports bulk processing of recently opened PRs.
 
 #### Internal changes
 
 - When parsing PR and issue numbers, treat `run_cmd()` result as an object, not a string.
 - E2e test for PR and issue number as target.
+- Uses a `cli_config` object, to store CLI args and behavioral settings off the pdata object.
+- Adds `httpx2`, for checking if provided URL is reachable.
+- In `test_all.sh`, run e2e and live user tests in parallel. ~14s -> ~5s.
 
 ### 0.7.1
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,35 @@ GitHub user: <redacted>
 For a more detailed report, run `gh-profiler <redacted>`.
 ```
 
+Bulk profiling of recent PRs
+---
+
+You can run concise profiles of the most recently opened PRs by passing the repo URL as the target:
+
+```txt
+$ uvx gh-profiler https://github.com/django/django
+PR 21427: Fixed #37147 -- Fixed rendering empty values for models with db_default on primary key.
+https://github.com/django/django/pull/21427
+
+  GitHub user: <redacted>
+  🟢 No concerns found with user's profile.
+  ...
+
+
+PR 21426: Fixed #37130 -- Skip DB cache deletion when culling offset is zero.
+https://github.com/django/django/pull/21426
+
+  GitHub user: <redacted>
+  🟢 No concerns found with user's profile.
+  ...
+```
+
+By default, this will process the 10 most recently opened PRs. If you want to process a different number, use the `-n` arg:
+
+```txt
+$ uvx gh-profiler <repo-url> -n 3
+```
+
 False positives
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.3.3",
+    "httpx2>=2.3.0",
     "humanize>=4.15.0",
 ]
 

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -13,6 +13,8 @@ from .utils.profile_data import profile_data as pdata
 @click.argument("target", required=False)
 @click.version_option(package_name="gh-profiler")
 @click.option("--concise", is_flag=True, help="Show concise output; one flag per category.")
+@click.option("-n", "--num-targets", default=10, help="Preview: How many PRs or issues to review?")
+@click.option("--issues", is_flag=True, help="Profile contributors of issues rather than PRs.")
 @click.option(
     "--generate-workflow",
     is_flag=True,

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -25,7 +25,7 @@ from .utils.cli_config import cli_config
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output, including explanations for decisions about flags.")
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
 @click.option("--benchmark-fetch", is_flag=True, help="Benchmark the code that fetches external data.")
-def main(target, concise, generate_workflow, verbose, redact, benchmark_fetch):
+def main(target, concise, num_targets, issues, back, generate_workflow, verbose, redact, benchmark_fetch):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
@@ -55,6 +55,12 @@ def main(target, concise, generate_workflow, verbose, redact, benchmark_fetch):
         gh_profiler.main()
         sys.exit()
 
+    # Check if we're processing a repo URL.
+    if "github.com" in target:
+        cli_config.url = target
+        _parse_repo_options(num_targets, issues, back)
+        gh_profiler.profile_url()
+
     # If the main argument is an integer, process the PR/issue number.
     # Otherwise, assume it's the username.
     try:
@@ -81,3 +87,9 @@ def _validate_command(target, concise, generate_workflow, verbose, redact, bench
     if target and generate_workflow:
         msg = "Please either include a target or --generate-workflow, but not both."
         sys.exit(msg)
+
+def _parse_repo_options(num_targets, issues, back):
+    """Get options relevant to targeting a repo URL."""
+    cli_config.num_targets = num_targets
+    cli_config.issues = issues
+    cli_config.back = back

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -7,6 +7,7 @@ import click
 from . import gh_profiler
 from .utils import cli_utils
 from .utils.profile_data import profile_data as pdata
+from .utils.cli_config import cli_config
 
 
 @click.command()
@@ -15,6 +16,7 @@ from .utils.profile_data import profile_data as pdata
 @click.option("--concise", is_flag=True, help="Show concise output; one flag per category.")
 @click.option("-n", "--num-targets", default=10, help="Preview: How many PRs or issues to review?")
 @click.option("--issues", is_flag=True, help="Profile contributors of issues rather than PRs.")
+@click.option("--back", is_flag=True, help="Look back over recently merged and closed PRs/issues.")
 @click.option(
     "--generate-workflow",
     is_flag=True,

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -1,12 +1,14 @@
 """Main CLI entry point for gh-profiler."""
 
 import sys
+from urllib.parse import urlparse
 
 import click
 
 from . import gh_profiler
 from .utils import cli_utils
 from .utils.profile_data import profile_data as pdata
+from .utils.repo_data import repo_data
 from .utils.cli_config import cli_config
 
 
@@ -59,6 +61,7 @@ def main(target, concise, num_targets, issues, back, generate_workflow, verbose,
     if "github.com" in target:
         cli_config.url = target
         _parse_repo_options(num_targets, issues, back)
+        _parse_repo_info(target)
         gh_profiler.profile_url()
 
     # If the main argument is an integer, process the PR/issue number.
@@ -93,3 +96,13 @@ def _parse_repo_options(num_targets, issues, back):
     cli_config.num_targets = num_targets
     cli_config.issues = issues
     cli_config.back = back
+
+def _parse_repo_info(target):
+    """Parse info about the repo from the target.
+
+    Looking for owner and repo name.
+    """
+    parsed_url = urlparse(target)
+    url_parts = parsed_url.path.split("/")
+    repo_data.owner = url_parts[1]
+    repo_data.repo_name = url_parts[2]

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -42,6 +42,11 @@ def main(target, concise, num_targets, back, generate_workflow, verbose, redact,
     $ gh-profiler ehmatthes
     $ python -m gh_profiler ehmatthes
       ...
+
+    \b
+    Bulk concise profiling of most recently opened PRs:
+    $ gh-profiler <repo-url>    # 10 most recent PRs
+    $ gh-profiler <repo-url> -n 3
     """
     _validate_command(target, concise, generate_workflow, verbose, redact, benchmark_fetch)
 

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -27,7 +27,7 @@ from .utils.cli_config import cli_config
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output, including explanations for decisions about flags.")
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
 @click.option("--benchmark-fetch", is_flag=True, help="Benchmark the code that fetches external data.")
-def main(target, concise, num_targets, issues, back, generate_workflow, verbose, redact, benchmark_fetch):
+def main(target, concise, num_targets, back, generate_workflow, verbose, redact, benchmark_fetch):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
@@ -60,7 +60,7 @@ def main(target, concise, num_targets, issues, back, generate_workflow, verbose,
     # Check if we're processing a repo URL.
     if "github.com" in target:
         cli_config.url = target
-        _parse_repo_options(num_targets, issues, back)
+        _parse_repo_options(num_targets, back)
         _parse_repo_info(target)
         gh_profiler.profile_url()
 
@@ -91,10 +91,10 @@ def _validate_command(target, concise, generate_workflow, verbose, redact, bench
         msg = "Please either include a target or --generate-workflow, but not both."
         sys.exit(msg)
 
-def _parse_repo_options(num_targets, issues, back):
+def _parse_repo_options(num_targets, back):
     """Get options relevant to targeting a repo URL."""
     cli_config.num_targets = num_targets
-    cli_config.issues = issues
+    # cli_config.issues = issues
     cli_config.back = back
 
 def _parse_repo_info(target):

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -16,9 +16,9 @@ from .utils.cli_config import cli_config
 @click.argument("target", required=False)
 @click.version_option(package_name="gh-profiler")
 @click.option("--concise", is_flag=True, help="Show concise output; one flag per category.")
-@click.option("-n", "--num-targets", default=10, help="Preview: How many PRs or issues to review?")
-@click.option("--issues", is_flag=True, help="Profile contributors of issues rather than PRs.")
-@click.option("--back", is_flag=True, help="Look back over recently merged and closed PRs/issues.")
+@click.option("-n", "--num-targets", default=10, help="Preview: How many PRs to review?")
+# @click.option("--issues", is_flag=True, help="Profile contributors of issues rather than PRs.")
+@click.option("--back", is_flag=True, help="Look back over recently merged and closed PRs.")
 @click.option(
     "--generate-workflow",
     is_flag=True,

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -28,3 +28,21 @@ def main():
 
     # Summarize findings.
     summary_utils.show_summary()
+
+def profile_url():
+    """Profile contributors of PRs or issues on a specific repo.
+    
+    Usage:
+    # Profile contributors of the most recent 10 open PRs (concise):
+    $ gh-profiler <repo>
+
+    # Most recent 20 PRs:
+    $ gh-profiler <repo> -n 20
+
+    # Most recent merged/closed PRs (shows profile, and end state):
+    $ gh-profiler <repo> --back
+
+    # Most recently opened issues:
+    $ gh-profiler <repo> --issues
+    """
+    

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -11,6 +11,7 @@ from .utils import profile_utils
 from .utils import analysis_utils
 from .utils import workflow_utils
 from .utils import summary_utils
+from .utils import repo_fetching
 
 
 def main():
@@ -28,6 +29,9 @@ def main():
 
     # Summarize findings.
     summary_utils.show_summary()
+
+    # Don't return to cli.
+    sys.exit()
 
 def profile_url():
     """Profile contributors of PRs or issues on a specific repo.
@@ -47,4 +51,9 @@ def profile_url():
     """
     # Make sure gh is available.
     profile_utils.ensure_gh()
-    
+
+    # Get and analyze all the data we'll need.
+    repo_fetching.get_data()
+
+    # Don't return to cli.
+    sys.exit()

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -45,4 +45,6 @@ def profile_url():
     # Most recently opened issues:
     $ gh-profiler <repo> --issues
     """
+    # Make sure gh is available.
+    profile_utils.ensure_gh()
     

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -11,7 +11,7 @@ from .utils import profile_utils
 from .utils import analysis_utils
 from .utils import workflow_utils
 from .utils import summary_utils
-from .utils import repo_fetching
+from .utils import repo_fetching, repo_analysis
 
 
 def main():

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -53,7 +53,8 @@ def profile_url():
     profile_utils.ensure_gh()
 
     # Get and analyze all the data we'll need.
-    repo_fetching.get_data()
+    target_prs = repo_fetching.get_data()
+    repo_analysis.process_data(target_prs)
 
     # Don't return to cli.
     sys.exit()

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -11,7 +11,7 @@ from .utils import profile_utils
 from .utils import analysis_utils
 from .utils import workflow_utils
 from .utils import summary_utils
-from .utils import repo_fetching, repo_analysis
+from .utils import repo_fetching, repo_analysis, repo_summary
 
 
 def main():
@@ -55,6 +55,7 @@ def profile_url():
     # Get and analyze all the data we'll need.
     target_prs = repo_fetching.get_data()
     repo_analysis.process_data(target_prs)
+    repo_summary.show_summary(target_prs)
 
     # Don't return to cli.
     sys.exit()

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -55,7 +55,10 @@ def profile_url():
     # Get and analyze all the data we'll need.
     target_prs = repo_fetching.get_data()
     repo_analysis.process_data(target_prs)
-    repo_summary.show_summary(target_prs)
+
+    # DEV: This will be used when bulk processing of PRs is done in parallel.
+    # That requires pdata to not be a singleton.
+    # repo_summary.show_summary(target_prs)
 
     # Don't return to cli.
     sys.exit()

--- a/src/gh_profiler/utils/cli_config.py
+++ b/src/gh_profiler/utils/cli_config.py
@@ -1,0 +1,16 @@
+"""One place to store all CLI options passed by the user."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CLIConfig:
+    """The main place to store options that are passed in the gh-profiler cmd.
+    """
+
+    # If target is a URL, store that here.
+    url: str = ""
+    num_targets: int | None = None
+
+
+cli_config = CLIConfig()

--- a/src/gh_profiler/utils/cli_config.py
+++ b/src/gh_profiler/utils/cli_config.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(slots=True)
 class CLIConfig:
     """The main place to store options that are passed in the gh-profiler cmd.
     """
@@ -11,6 +11,9 @@ class CLIConfig:
     # If target is a URL, store that here.
     url: str = ""
     num_targets: int | None = None
+
+    issues: bool | None = None
+    back: bool | None = None
 
 
 cli_config = CLIConfig()

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -109,7 +109,6 @@ def _fetch_profile_dict():
     """Fetch the profile information we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
     result = infra_utils.run_cmd(cmd)
-
     return result.stdout
 
 def _parse_profile_dict(profile_dict_str):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -19,8 +19,15 @@ def process_data(target_prs):
         profile_utils.get_data()
         analysis_utils.process_data()
         summary = summary_utils._get_concise_summary()
+        summary = _indent_summary(summary)
 
-        print(f"\nPR number: {pr.pr_num}")
-        print(f"  {pr.title}")
+        print(f"PR {pr.pr_num}: {pr.title}")
         print(summary)
+        print("\n")
 
+
+def _indent_summary(summary):
+    """Indent the summary, to fit in this larger set of output."""
+    lines = summary.splitlines()
+    lines = [f"  {l}" for l in lines]
+    return "\n".join(lines)

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -12,23 +12,39 @@ def process_data(target_prs):
     Evaluates results.
     """
     for pr in target_prs:
-        # Get concise gh-profiler output for author.
+        # Get concise gh-profiler output for PR author.
         pdata.username = pr.author
-        # breakpoint()
         profile_utils.get_data()
         analysis_utils.process_data()
-        summary = summary_utils._get_concise_summary()
-        summary = _indent_summary(summary)
+        author_summary = summary_utils._get_concise_summary()
+        pr_summary = _get_pr_summary(pr, author_summary)
 
-        print(f"PR {pr.pr_num}: {pr.title}")
-        print(f"  {pr.url}")
-        print("")
-        print(summary)
-        print("\n")
+        print(pr_summary)
+
+        
 
 
-def _indent_summary(summary):
-    """Indent the summary, to fit in this larger set of output."""
+def _adjust_author_summary(summary):
+    """Modify standard concise output to fit bulk reporting needs.
+
+    - Remove closing line about running a detailed report.
+    - Indent lines
+    """
     lines = summary.splitlines()
+    # Remove "For a more detailed report..."
+    lines = lines[:-2]
+    # Indent lines.
     lines = [f"  {l}" for l in lines]
+
     return "\n".join(lines)
+
+def _get_pr_summary(pr, author_summary):
+    """Get the summary for an individual PR."""
+    author_summary = _adjust_author_summary(author_summary)
+
+    pr_summary = f"PR {pr.pr_num}: {pr.title}"
+    pr_summary += f"\n  {pr.url}\n\n"
+    pr_summary += author_summary
+    pr_summary += "\n"
+
+    return pr_summary

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -19,6 +19,11 @@ def process_data(target_prs):
         author_summary = summary_utils._get_concise_summary()
         pr.summary = _get_pr_summary(pr, author_summary)
 
+        # DEV: Print the summary here while we're not doing this in parallel.
+        # When these are being processed in parallel, we'll remove this line
+        # and call show_summary() from gh_profiler.
+        print(pr.summary)
+
         
 def _adjust_author_summary(summary):
     """Modify standard concise output to fit bulk reporting needs.

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -22,6 +22,8 @@ def process_data(target_prs):
         summary = _indent_summary(summary)
 
         print(f"PR {pr.pr_num}: {pr.title}")
+        print(f"  {pr.url}")
+        print("")
         print(summary)
         print("\n")
 

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -22,8 +22,6 @@ def process_data(target_prs):
         print(pr_summary)
 
         
-
-
 def _adjust_author_summary(summary):
     """Modify standard concise output to fit bulk reporting needs.
 
@@ -43,8 +41,8 @@ def _get_pr_summary(pr, author_summary):
     author_summary = _adjust_author_summary(author_summary)
 
     pr_summary = f"PR {pr.pr_num}: {pr.title}"
-    pr_summary += f"\n  {pr.url}\n\n"
+    pr_summary += f"\n{pr.url}\n\n"
     pr_summary += author_summary
-    pr_summary += "\n"
+    pr_summary += "\n\n"
 
     return pr_summary

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -2,7 +2,6 @@
 
 from .profile_data import profile_data as pdata
 from . import profile_utils, analysis_utils, summary_utils
-from . import flags
 
 
 def process_data(target_prs):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -17,9 +17,7 @@ def process_data(target_prs):
         profile_utils.get_data()
         analysis_utils.process_data()
         author_summary = summary_utils._get_concise_summary()
-        pr_summary = _get_pr_summary(pr, author_summary)
-
-        print(pr_summary)
+        pr.summary = _get_pr_summary(pr, author_summary)
 
         
 def _adjust_author_summary(summary):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -1,0 +1,26 @@
+"""Utils for analyzing repo data."""
+
+from .profile_data import profile_data as pdata
+from . import profile_utils, analysis_utils, summary_utils
+from . import flags
+
+
+def process_data(target_prs):
+    """Process a list of PRs.
+    
+    Takes a list of PRData objects.
+    Calls gh-profiler on each PR author.
+    Evaluates results.
+    """
+    for pr in target_prs:
+        # Get concise gh-profiler output for author.
+        pdata.username = pr.author
+        # breakpoint()
+        profile_utils.get_data()
+        analysis_utils.process_data()
+        summary = summary_utils._get_concise_summary()
+
+        print(f"\nPR number: {pr.pr_num}")
+        print(f"  {pr.title}")
+        print(summary)
+

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -15,10 +15,14 @@ class RepoData:
 @dataclass(slots=True)
 class PRData:
     """Data store for a PR we're targeting."""
+    # Raw info
     pr_num: int | None = None
     author: str = ""
     title: str = ""
     url: str = ""
+
+    # Processed info
+    summary: str = ""
 
 
 repo_data = RepoData()

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -12,4 +12,13 @@ class RepoData:
     repo_name: str = ""
 
 
+@dataclass(slots=True)
+class PRData:
+    """Data store for a PR we're targeting."""
+    pr_id: int | None = None
+    author: str = ""
+    title: str = ""
+    url: str = ""
+
+
 repo_data = RepoData()

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -1,0 +1,15 @@
+"""One place to store all data about the targeted repo."""
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class RepoData:
+    """The main data store for what we need to know about a targeted repo.
+
+    """
+    owner: str = ""
+    repo_name: str = ""
+
+
+repo_data = RepoData()

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -15,7 +15,7 @@ class RepoData:
 @dataclass(slots=True)
 class PRData:
     """Data store for a PR we're targeting."""
-    pr_id: int | None = None
+    pr_num: int | None = None
     author: str = ""
     title: str = ""
     url: str = ""

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -46,7 +46,9 @@ def get_data():
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_reachable(reachable_str)
-    _parse_prs(prs_obj)
+    target_prs = _parse_prs(prs_obj)
+
+    return target_prs
 
 
 # --- Helper functions ---
@@ -90,13 +92,14 @@ def _parse_prs(prs_obj):
     target_prs = []
     for pr_dict in prs_json["data"]["repository"]["pullRequests"]["nodes"]:
         pr_data = PRData(
-            pr_id=pr_dict["id"],
+            pr_num=pr_dict["number"],
             author=pr_dict["author"],
             title=pr_dict["title"],
             url=pr_dict["url"],
         )
         target_prs.append(pr_data)
-    breakpoint()
+
+    return target_prs
 
 
 def _get_pr_query():
@@ -111,7 +114,6 @@ def _get_pr_query():
             orderBy: {{field: CREATED_AT, direction: DESC}}
             ) {{
             nodes {{
-                id
                 number
                 title
                 url

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -12,6 +12,7 @@ from collections import Counter
 
 from . import infra_utils
 from .profile_data import profile_data as pdata
+from .repo_data import repo_data
 from .cli_config import cli_config
 
 import httpx2
@@ -37,7 +38,7 @@ def get_data():
 
         # When each call finishes, store the result.
         reachable_str = reachable_future.result()
-        prs_str = prs_future.result()
+        prs_obj = prs_future.result()
 
     ts_after = perf_counter()
     if pdata.benchmark_fetch:
@@ -45,7 +46,7 @@ def get_data():
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_reachable(reachable_str)
-    _parse_prs(prs_str)
+    _parse_prs(prs_obj)
 
 
 # --- Helper functions ---
@@ -74,8 +75,41 @@ def _fetch_prs():
     For each PR:
     - username, title, id
     """
-    ...
+    pr_query = _get_pr_query()
+    result = infra_utils.run_cmd(pr_query)
+    return result
 
-def _parse_prs(prs_str):
-    """Parse required info from PR string."""
-    ...
+
+def _parse_prs(prs_obj):
+    """Parse required info from PR query."""
+    prs_str = prs_obj.stdout
+    prs_json = json.loads(prs_str)
+    breakpoint()
+
+
+def _get_pr_query():
+    """Return the gh call for recent open PRs in a repo."""
+    gh_call = f"""
+        gh api graphql -f query='
+        query($owner: String!, $repo: String!, $n: Int!) {{
+        repository(owner: $owner, name: $repo) {{
+            pullRequests(
+            first: $n,
+            states: OPEN,
+            orderBy: {{field: CREATED_AT, direction: DESC}}
+            ) {{
+            nodes {{
+                id
+                number
+                title
+                url
+                author {{
+                login
+                }}
+            }}
+            }}
+        }}
+        }}' -F owner='{repo_data.owner}' -F repo='{repo_data.repo_name}' -F n={cli_config.num_targets}
+    """
+
+    return dedent(gh_call).strip()

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -32,10 +32,10 @@ def get_data():
     ts_before = perf_counter()
     with ThreadPoolExecutor() as executor:
         # Make fetching calls.
-        status_reachable = executor.submit(_fetch_reachable)
+        reachable_future = executor.submit(_fetch_reachable)
 
         # When each call finishes, store the result.
-        reachable_str = status_future.result()
+        reachable_str = reachable_future.result()
 
     ts_after = perf_counter()
     if pdata.benchmark_fetch:
@@ -60,6 +60,6 @@ def _parse_reachable(reachable_str):
     if reachable_str == 200:
         return
 
-    msg = f"URL returned status code {reachable_str}"
-    msg += "  Is the URL correct?"
+    msg = f"URL returned status code {reachable_str}."
+    msg += "\n  Is the URL correct?"
     sys.exit(msg)

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -33,11 +33,11 @@ def get_data():
     ts_before = perf_counter()
     with ThreadPoolExecutor() as executor:
         # Make fetching calls.
-        reachable_future = executor.submit(_fetch_reachable)
+        # reachable_future = executor.submit(_fetch_reachable)
         prs_future = executor.submit(_fetch_prs)
 
         # When each call finishes, store the result.
-        reachable_str = reachable_future.result()
+        # reachable_str = reachable_future.result()
         prs_obj = prs_future.result()
 
     ts_after = perf_counter()
@@ -45,7 +45,7 @@ def get_data():
         print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
 
     # Parse data. This should only happen after all data has been fetched.
-    _parse_reachable(reachable_str)
+    # _parse_reachable(reachable_str)
     target_prs = _parse_prs(prs_obj)
 
     return target_prs
@@ -93,7 +93,7 @@ def _parse_prs(prs_obj):
     for pr_dict in prs_json["data"]["repository"]["pullRequests"]["nodes"]:
         pr_data = PRData(
             pr_num=pr_dict["number"],
-            author=pr_dict["author"],
+            author=pr_dict["author"]["login"],
             title=pr_dict["title"],
             url=pr_dict["url"],
         )

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -33,9 +33,11 @@ def get_data():
     with ThreadPoolExecutor() as executor:
         # Make fetching calls.
         reachable_future = executor.submit(_fetch_reachable)
+        prs_future = executor.submit(_fetch_prs)
 
         # When each call finishes, store the result.
         reachable_str = reachable_future.result()
+        prs_str = prs_future.result()
 
     ts_after = perf_counter()
     if pdata.benchmark_fetch:
@@ -43,6 +45,7 @@ def get_data():
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_reachable(reachable_str)
+    _parse_prs(prs_str)
 
 
 # --- Helper functions ---
@@ -63,3 +66,16 @@ def _parse_reachable(reachable_str):
     msg = f"URL returned status code {reachable_str}."
     msg += "\n  Is the URL correct?"
     sys.exit(msg)
+
+def _fetch_prs():
+    """Fetch relevant PRs.
+    
+    Need: n most recently opened PRs.
+    For each PR:
+    - username, title, id
+    """
+    ...
+
+def _parse_prs(prs_str):
+    """Parse required info from PR string."""
+    ...

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -12,7 +12,7 @@ from collections import Counter
 
 from . import infra_utils
 from .profile_data import profile_data as pdata
-from .repo_data import repo_data
+from .repo_data import repo_data, PRData
 from .cli_config import cli_config
 
 import httpx2
@@ -84,6 +84,18 @@ def _parse_prs(prs_obj):
     """Parse required info from PR query."""
     prs_str = prs_obj.stdout
     prs_json = json.loads(prs_str)
+
+    # Build a list of usernames to profile, along with relevant PR title
+    # and number.
+    target_prs = []
+    for pr_dict in prs_json["data"]["repository"]["pullRequests"]["nodes"]:
+        pr_data = PRData(
+            pr_id=pr_dict["id"],
+            author=pr_dict["author"],
+            title=pr_dict["title"],
+            url=pr_dict["url"],
+        )
+        target_prs.append(pr_data)
     breakpoint()
 
 

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -1,0 +1,65 @@
+"""Utils for retrieving repo information when targeting a URL."""
+
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime as dt
+from datetime import timedelta
+from datetime import timezone as tz
+from textwrap import dedent
+from time import perf_counter
+from collections import Counter
+
+from . import infra_utils
+from .profile_data import profile_data as pdata
+from .cli_config import cli_config
+
+import httpx2
+
+
+def get_data():
+    """Get all repo-level data we'll need from GitHub.
+    
+    Repo-level data includes things like which PR or issue numbers are we
+    targeting.
+
+    Fetch all data we'll need, then parse it into the data structures that
+    can be analyzed and processed.
+    """
+    # Fetch data. This can all be done in parallel. The benchmarking is here
+    # because this is the slowest part of the program, and it's helpful at
+    # times to benchmark just this fetching code.
+    ts_before = perf_counter()
+    with ThreadPoolExecutor() as executor:
+        # Make fetching calls.
+        status_reachable = executor.submit(_fetch_reachable)
+
+        # When each call finishes, store the result.
+        reachable_str = status_future.result()
+
+    ts_after = perf_counter()
+    if pdata.benchmark_fetch:
+        print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
+
+    # Parse data. This should only happen after all data has been fetched.
+    _parse_reachable(reachable_str)
+
+
+# --- Helper functions ---
+
+def _fetch_reachable():
+    """Fetch page at URL.
+    
+    Make sure this URL is reachable.
+    """
+    r = httpx2.get(cli_config.url)
+    return r.status_code
+
+def _parse_reachable(reachable_str):
+    """Parse output of reachable call."""
+    if reachable_str == 200:
+        return
+
+    msg = f"URL returned status code {reachable_str}"
+    msg += "  Is the URL correct?"
+    sys.exit(msg)

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -3,12 +3,8 @@
 import json
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime as dt
-from datetime import timedelta
-from datetime import timezone as tz
 from textwrap import dedent
 from time import perf_counter
-from collections import Counter
 
 from . import infra_utils
 from .profile_data import profile_data as pdata

--- a/src/gh_profiler/utils/repo_summary.py
+++ b/src/gh_profiler/utils/repo_summary.py
@@ -1,0 +1,9 @@
+"""Utils for summarizing bulk PRs."""
+
+
+
+
+def show_summary(target_prs):
+    """Show summary for all processed PRs."""
+    for pr in target_prs:
+        print(pr.summary)

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -30,6 +30,9 @@ def _get_concise_summary():
 
     This is one line for each main section: name, profile, pr activity, issue activity.
     """
+    if pdata.redact:
+        _redact_info()
+    
     summary = ""
     summary += f"GitHub user: {pdata.username}\n"
     summary += _get_profile_header()

--- a/test_all.sh
+++ b/test_all.sh
@@ -8,7 +8,7 @@
 uv run pytest
 
 # E2e tests.
-uv run pytest tests/e2e_tests
+uv run pytest tests/e2e_tests -n auto
 
 # Tests against actual users.
-uv run pytest developer_resources/test_actual_users.py -s
+uv run pytest developer_resources/test_actual_users.py -s -n auto

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -128,3 +128,14 @@ def test_redact():
 
     # Should currently see 7 redacted fields in my output.
     assert output.count("<redacted>") == 7
+
+def test_bulk_open_prs():
+    """Test a run against a repo URL for bulk processing open PRs."""
+    # Django is likely to have many open PRs.
+    url = "https://github.com/django/django"
+    cmd = f"uv run gh-profiler {url} -n 3"
+    output = run_with_timeout(cmd)
+
+    assert output.count("PR ") == 3
+    assert output.count("https://github.com/django/django/pull/") == 3
+    assert output.count("GitHub user: ") == 3

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -5,7 +5,6 @@ Makes an actual gh-profiler call. Currently calls against my own user account
 to use.
 """
 
-import sys
 import subprocess
 
 import pytest

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -6,6 +6,7 @@ to use.
 """
 
 import subprocess
+import re
 
 import pytest
 
@@ -136,6 +137,11 @@ def test_bulk_open_prs():
     cmd = f"uv run gh-profiler {url} -n 3"
     output = run_with_timeout(cmd)
 
-    assert output.count("PR ") == 3
     assert output.count("https://github.com/django/django/pull/") == 3
     assert output.count("GitHub user: ") == 3
+
+    # Check that there are 3 PR numbers and titles in output.
+    re_pr_title = r"(PR \d+: ).*"
+    matches = re.findall(re_pr_title, output)
+    assert len(matches) == 3
+

--- a/tests/unit_tests/test_flag_evaluations.py
+++ b/tests/unit_tests/test_flag_evaluations.py
@@ -4,7 +4,6 @@ from gh_profiler.utils import analysis_utils
 from gh_profiler.utils import summary_utils
 from gh_profiler.utils.profile_data import profile_data as pdata
 from gh_profiler.utils import flags
-from reference_files import reference_summaries
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,20 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -50,6 +64,7 @@ version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "httpx2" },
     { name = "humanize" },
 ]
 
@@ -62,6 +77,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
+    { name = "httpx2", specifier = ">=2.3.0" },
     { name = "humanize", specifier = ">=4.15.0" },
 ]
 
@@ -72,12 +88,58 @@ dev = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/34/18f1c596e677962f040284246f393b10a1f8ce440b3a7e69c637d0f1c7ad/httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924", size = 64300, upload-time = "2026-06-01T13:15:02.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415", size = 80024, upload-time = "2026-06-01T13:15:00.001Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/9a/cca0b9145f13d8ae34b885ae28d403a1469a433abc78e0f94f4ce94e650b/httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9", size = 81115, upload-time = "2026-06-01T13:15:04.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7", size = 74538, upload-time = "2026-06-01T13:15:01.566Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -199,6 +261,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Support the following usage:

```txt
# Profile contributors of the most recent 10 open PRs (concise):
$ gh-profiler <repo>

# Most recent 20 PRs:
$ gh-profiler <repo> -n 20
```

From changelog:

- Uses a `cli_config` object, to store CLI args and behavioral settings off the pdata object.
- Adds `httpx2`, for checking if provided URL is reachable.
- In `test_all.sh`, run e2e and live user tests in parallel. ~14s -> ~5s.