### PR TITLE
Support --back arg to look back at merged and closed PRs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ These initial releases have usable behavior, but may have some rough edges for s
 
 - Redacts user's org info.
 - Fixes broken usage against PRs and issue numbers, since 0.6.6.
-- Supports bulk processing of recently opened PRs.
+- Supports bulk processing of recently opened and closed PRs.
 
 #### Internal changes
 
@@ -23,6 +23,9 @@ These initial releases have usable behavior, but may have some rough edges for s
 - Uses a `cli_config` object, to store CLI args and behavioral settings off the pdata object.
 - Adds `httpx2`, for checking if provided URL is reachable.
 - In `test_all.sh`, run e2e and live user tests in parallel. ~14s -> ~5s.
+- Uses Rich for tabular output. Will be easier to clean up existing output as well.
+- Special case for handling GitHub's `ghost` user, a stand-in for deleted accounts.
+- Method to reset `pdata` instances, should be removed when `pdata` is not a singleton.
 
 ### 0.7.1
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Fetching user profiles ..........
 ```
 
 > [!NOTE]
-> When using `--back` to look at merged and closed PRs, the output may differ from what you see on GitHub's PR tab in the corresponding repo. The gh API returns a different filtered set than what we see when we click "closed" on the PR tab in a browser.
+> When using `--back` to look at merged and closed PRs, the output may differ from what you see on GitHub's PR tab in the corresponding repo. The gh API returns a different filtered set than what we see when we click "closed" on the PR tab in a browser. The data you see for each PR should be accurate; if it's not, please open an issue.
 
 False positives
 ---

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ Fetching user profiles ..........
 └────────┴─────────┴─────────────┴────────────┴─────────────────────────────────────────────┘
 ```
 
+> [!NOTE]
+> When using `--back` to look at merged and closed PRs, the output may differ from what you see on GitHub's PR tab in the corresponding repo. The gh API returns a different filtered set than what we see when we click "closed" on the PR tab in a browser.
+
 False positives
 ---
 

--- a/README.md
+++ b/README.md
@@ -146,12 +146,41 @@ https://github.com/django/django/pull/21426
   GitHub user: <redacted>
   🟢 No concerns found with user's profile.
   ...
+
+            Comparison of gh-profiler results with final merged state:             
+┏━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ PR num ┃ gh-profiler ┃ Author     ┃ PR link                                     ┃
+┡━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 21427  │ 🟢🟢🟢      │ <redacted> │ https://github.com/django/django/pull/21427 │
+│ 21425  │ 🔴🟡🟢      │ <redacted> │ https://github.com/django/django/pull/21425 │
+...
+│ 21416  │ 🟢🟢🟢      │ <redacted> │ https://github.com/django/django/pull/21416 │
+│ 21415  │ 🟡🟢🟢      │ <redacted> │ https://github.com/django/django/pull/21415 │
+└────────┴─────────────┴────────────┴─────────────────────────────────────────────┘
 ```
 
 By default, this will process the 10 most recently opened PRs. If you want to process a different number, use the `-n` arg:
 
 ```txt
 $ uvx gh-profiler <repo-url> -n 3
+```
+
+You can also look back at the most recently closed PRs, and request just the final summary table:
+
+```txt
+$ uv run gh-profiler https://github.com/django/django --back --table-only --redact
+Fetching user profiles ..........
+
+                 Comparison of gh-profiler results with final merged state:                  
+┏━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ PR num ┃ Merged? ┃ gh-profiler ┃ Author     ┃ PR link                                     ┃
+┡━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 21428  │   🔴    │ 🟢🟢🟢      │ <redacted> │ https://github.com/django/django/pull/21428 │
+│ 21423  │   🔴    │ 🔴🟡🟢      │ <redacted> │ https://github.com/django/django/pull/21423 │
+│ 21197  │   🟣    │ 🟢🟢🟢      │ <redacted> │ https://github.com/django/django/pull/21197 │
+...
+│ 21401  │   🟣    │ 🟢🟢🟢      │ <redacted> │ https://github.com/django/django/pull/21401 │
+└────────┴─────────┴─────────────┴────────────┴─────────────────────────────────────────────┘
 ```
 
 False positives

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "click>=8.3.3",
     "httpx2>=2.3.0",
     "humanize>=4.15.0",
+    "rich>=15.0.0",
 ]
 
 [project.scripts]

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -19,6 +19,7 @@ from .utils.cli_config import cli_config
 @click.option("-n", "--num-targets", default=10, help="Preview: How many PRs to review?")
 # @click.option("--issues", is_flag=True, help="Profile contributors of issues rather than PRs.")
 @click.option("--back", is_flag=True, help="Look back over recently merged and closed PRs.")
+@click.option("--compare-only", is_flag=True, help="For bulk processing, only show comparison table.")
 @click.option(
     "--generate-workflow",
     is_flag=True,
@@ -27,7 +28,7 @@ from .utils.cli_config import cli_config
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output, including explanations for decisions about flags.")
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
 @click.option("--benchmark-fetch", is_flag=True, help="Benchmark the code that fetches external data.")
-def main(target, concise, num_targets, back, generate_workflow, verbose, redact, benchmark_fetch):
+def main(target, concise, num_targets, back, compare_only, generate_workflow, verbose, redact, benchmark_fetch):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
@@ -65,7 +66,7 @@ def main(target, concise, num_targets, back, generate_workflow, verbose, redact,
     # Check if we're processing a repo URL.
     if "github.com" in target:
         cli_config.url = target
-        _parse_repo_options(num_targets, back, redact)
+        _parse_repo_options(num_targets, back, redact, compare_only)
         _parse_repo_info(target)
         gh_profiler.profile_url()
 
@@ -96,12 +97,13 @@ def _validate_command(target, concise, generate_workflow, verbose, redact, bench
         msg = "Please either include a target or --generate-workflow, but not both."
         sys.exit(msg)
 
-def _parse_repo_options(num_targets, back, redact):
+def _parse_repo_options(num_targets, back, redact, compare_only):
     """Get options relevant to targeting a repo URL."""
     cli_config.num_targets = num_targets
     # cli_config.issues = issues
     cli_config.back = back
     cli_config.redact = redact
+    cli_config.compare_only = compare_only
 
 def _parse_repo_info(target):
     """Parse info about the repo from the target.

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -19,7 +19,7 @@ from .utils.cli_config import cli_config
 @click.option("-n", "--num-targets", default=10, help="Preview: How many PRs to review?")
 # @click.option("--issues", is_flag=True, help="Profile contributors of issues rather than PRs.")
 @click.option("--back", is_flag=True, help="Look back over recently merged and closed PRs.")
-@click.option("--compare-only", is_flag=True, help="For bulk processing, only show comparison table.")
+@click.option("--table-only", is_flag=True, help="For bulk processing, only show comparison table.")
 @click.option(
     "--generate-workflow",
     is_flag=True,
@@ -28,7 +28,7 @@ from .utils.cli_config import cli_config
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output, including explanations for decisions about flags.")
 @click.option("--redact", is_flag=True, help="Redact identifying information.")
 @click.option("--benchmark-fetch", is_flag=True, help="Benchmark the code that fetches external data.")
-def main(target, concise, num_targets, back, compare_only, generate_workflow, verbose, redact, benchmark_fetch):
+def main(target, concise, num_targets, back, table_only, generate_workflow, verbose, redact, benchmark_fetch):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
     You can target a GitHub username, or a PR/issue number from the repository you're working in.
@@ -66,7 +66,7 @@ def main(target, concise, num_targets, back, compare_only, generate_workflow, ve
     # Check if we're processing a repo URL.
     if "github.com" in target:
         cli_config.url = target
-        _parse_repo_options(num_targets, back, redact, compare_only)
+        _parse_repo_options(num_targets, back, redact, table_only)
         _parse_repo_info(target)
         gh_profiler.profile_url()
 
@@ -97,13 +97,13 @@ def _validate_command(target, concise, generate_workflow, verbose, redact, bench
         msg = "Please either include a target or --generate-workflow, but not both."
         sys.exit(msg)
 
-def _parse_repo_options(num_targets, back, redact, compare_only):
+def _parse_repo_options(num_targets, back, redact, table_only):
     """Get options relevant to targeting a repo URL."""
     cli_config.num_targets = num_targets
     # cli_config.issues = issues
     cli_config.back = back
     cli_config.redact = redact
-    cli_config.compare_only = compare_only
+    cli_config.table_only = table_only
 
 def _parse_repo_info(target):
     """Parse info about the repo from the target.

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -65,7 +65,7 @@ def main(target, concise, num_targets, back, generate_workflow, verbose, redact,
     # Check if we're processing a repo URL.
     if "github.com" in target:
         cli_config.url = target
-        _parse_repo_options(num_targets, back)
+        _parse_repo_options(num_targets, back, redact)
         _parse_repo_info(target)
         gh_profiler.profile_url()
 
@@ -96,11 +96,12 @@ def _validate_command(target, concise, generate_workflow, verbose, redact, bench
         msg = "Please either include a target or --generate-workflow, but not both."
         sys.exit(msg)
 
-def _parse_repo_options(num_targets, back):
+def _parse_repo_options(num_targets, back, redact):
     """Get options relevant to targeting a repo URL."""
     cli_config.num_targets = num_targets
     # cli_config.issues = issues
     cli_config.back = back
+    cli_config.redact = redact
 
 def _parse_repo_info(target):
     """Parse info about the repo from the target.

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -46,8 +46,14 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
 
     \b
     Bulk concise profiling of most recently opened PRs:
-    $ gh-profiler <repo-url>    # 10 most recent PRs
+    $ gh-profiler <repo-url>  # 10 most recent PRs
     $ gh-profiler <repo-url> -n 3
+    $ gh-profiler <repo-url> --table-only
+
+    \b
+    Look back at most recently merged/closed PRs:
+    $ gh-profiler <repo-url> --back
+    $ gh-profiler <repo-url> --back -n 20 --table-only
     """
     _validate_command(target, concise, generate_workflow, verbose, redact, benchmark_fetch)
 

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -11,7 +11,7 @@ def process_data():
     """Process all data."""
     if pdata.username == "ghost":
         # This is GitHub's deleted user, and we don't need to do anything.
-        pdata.flag_overall_profile == flags.red_flag
+        pdata.flag_overall_profile = flags.red_flag
         return
         
     _process_account_age()

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -11,6 +11,7 @@ def process_data():
     """Process all data."""
     if pdata.username == "ghost":
         # This is GitHub's deleted user, and we don't need to do anything.
+        pdata.flag_overall_profile == flags.red_flag
         return
         
     _process_account_age()

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -9,6 +9,10 @@ from . import flags
 
 def process_data():
     """Process all data."""
+    if pdata.username == "ghost":
+        # This is GitHub's deleted user, and we don't need to do anything.
+        return
+        
     _process_account_age()
     _process_profile_info()
     _process_pr_activity()

--- a/src/gh_profiler/utils/cli_config.py
+++ b/src/gh_profiler/utils/cli_config.py
@@ -16,7 +16,7 @@ class CLIConfig:
     back: bool | None = None
 
     redact: bool | None = None
-    compare_only: bool | None = None
+    table_only: bool | None = None
 
 
 cli_config = CLIConfig()

--- a/src/gh_profiler/utils/cli_config.py
+++ b/src/gh_profiler/utils/cli_config.py
@@ -15,5 +15,7 @@ class CLIConfig:
     issues: bool | None = None
     back: bool | None = None
 
+    redact: bool | None = None
+
 
 cli_config = CLIConfig()

--- a/src/gh_profiler/utils/cli_config.py
+++ b/src/gh_profiler/utils/cli_config.py
@@ -16,6 +16,7 @@ class CLIConfig:
     back: bool | None = None
 
     redact: bool | None = None
+    compare_only: bool | None = None
 
 
 cli_config = CLIConfig()

--- a/src/gh_profiler/utils/flags.py
+++ b/src/gh_profiler/utils/flags.py
@@ -3,3 +3,5 @@
 red_flag = "\U0001f534"
 yellow_flag = "\U0001f7e1"
 green_flag = "\U0001f7e2"
+
+merged_flag = "\U0001f7e3"

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -84,6 +84,32 @@ class ProfileData:
 
     generate_workflow: bool = False
 
+    def reset_fields(self):
+        """Reset fields.
+        
+        DEV: This should be unnecessary when pdata is no longer used as a 
+        singleton object.
+        """
+        behavior_fields = {
+            "concise",
+            "verbose",
+            "redact",
+            "benchmark_fetch",
+            "generate_workflow",
+        }
+
+        for field in fields(self):
+            if field.name in behavior_fields:
+                continue
+
+            if field.default_factory is not MISSING:
+                value = field.default_factory()
+            else:
+                value = field.default
+
+            setattr(self, field.name, value)
+
+
 
 
 profile_data = ProfileData()

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -1,6 +1,6 @@
 """One place to store all data about the user."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, MISSING
 
 
 @dataclass(slots=True)

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -36,6 +36,10 @@ def get_data():
     Fetch all data we'll need, then parse it into the data structures that
     can be analyzed and processed.
     """
+    if pdata.username == "ghost":
+        # This is GitHub's deleted user, and we don't need to do anything.
+        return
+        
     # Fetch data. This can all be done in parallel. The benchmarking is here
     # because this is the slowest part of the program, and it's helpful at
     # times to benchmark just this fetching code.

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -2,6 +2,8 @@
 
 from .profile_data import profile_data as pdata
 from . import profile_utils, analysis_utils, summary_utils
+from . import flags
+from .cli_config import cli_config
 
 
 def process_data(target_prs):
@@ -47,8 +49,27 @@ def _get_pr_summary(pr, author_summary):
     author_summary = _adjust_author_summary(author_summary)
 
     pr_summary = f"PR {pr.pr_num}: {pr.title}"
-    pr_summary += f"\n{pr.url}\n\n"
+    pr_summary += _get_status_line(pr)
     pr_summary += author_summary
     pr_summary += "\n\n"
 
     return pr_summary
+
+def _get_status_line(pr):
+    """Get the line that shows the status of the PR.
+
+    For open PRs, no symbol.
+    For closed PRs, flag and state.
+    For all, this is where the PR URL goes as well.
+    """
+    # breakpoint()
+    if not cli_config.back:
+        return f"\n{pr.url}\n\n"
+    
+    if pr.closed_state == "MERGED":
+        status = f"{flags.merged_flag} Merged."
+    else:
+        status = f"{flags.red_flag} Closed."
+
+    return f"\n{status} {pr.url}\n\n"
+    

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -89,7 +89,7 @@ def show_table(target_prs):
             else:
                 merged_flag = flags.red_flag
         
-        profile_flags = " ".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
+        profile_flags = "".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
 
         if cli_config.back:
             table.add_row(str(pr.pr_num), merged_flag, pr.author, profile_flags, pr.url)

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -97,7 +97,6 @@ def _get_status_line(pr):
     For closed PRs, flag and state.
     For all, this is where the PR URL goes as well.
     """
-    # breakpoint()
     if not cli_config.back:
         return f"\n{pr.url}\n\n"
     

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -36,7 +36,7 @@ def _adjust_author_summary(summary):
     if pdata.username != "ghost":
         # Remove "For a more detailed report..."
         lines = lines[:-2]
-        
+
     # Indent lines.
     lines = [f"  {l}" for l in lines]
 

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -24,18 +24,19 @@ def process_data(target_prs):
         pdata.reset_fields()
         pdata.username = pr.author
 
-        if author_summary := _get_cached_author_summary(pdata.username, target_prs):
-            pr.author_summary = author_summary
+        if author_info := _get_cached_author_info(pdata.username, target_prs):
+            # breakpoint()
+            pr.author_summary, pr.profile_flag, pr.pr_flag, pr.issue_flag = author_info
         else:
             profile_utils.get_data()
             analysis_utils.process_data()
             pr.author_summary = summary_utils._get_concise_summary()
 
-        pr.summary = _get_pr_summary(pr, pr.author_summary)
+            pr.profile_flag = pdata.flag_overall_profile
+            pr.pr_flag = pdata.flag_overall_pr
+            pr.issue_flag = pdata.flag_overall_issues
 
-        pr.profile_flag = pdata.flag_overall_profile
-        pr.pr_flag = pdata.flag_overall_pr
-        pr.issue_flag = pdata.flag_overall_issues
+        pr.summary = _get_pr_summary(pr, pr.author_summary)
 
         # DEV: Print the summary here while we're not doing this in parallel.
         # When these are being processed in parallel, we'll remove this line
@@ -54,14 +55,18 @@ def process_data(target_prs):
             print("\n")
         compare_results(target_prs)
 
-def _get_cached_author_summary(username, target_prs):
+def _get_cached_author_info(username, target_prs):
     """Get an existing author summary if it's already been built."""
     author_prs = [pr for pr in target_prs if pr.author == username]
 
     for pr in author_prs:
         if pr.author_summary:
-            return pr.author_summary
-
+            return (
+                pr.author_summary,
+                pr.profile_flag,
+                pr.pr_flag,
+                pr.issue_flag,
+            )
 
 
 def compare_results(target_prs):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -16,6 +16,9 @@ def process_data(target_prs):
     Calls gh-profiler on each PR author.
     Evaluates results.
     """
+    if cli_config.compare_only:
+        print("Fetching user profiles ", end="", flush=True)
+        
     for pr in target_prs:
         # Get concise gh-profiler output for PR author.
         pdata.reset_fields()
@@ -35,9 +38,15 @@ def process_data(target_prs):
         # Also, redacting here for now.
         if cli_config.redact:
             pr.author = "<redacted>"
-        print(pr.summary)
+
+        if cli_config.back and cli_config.compare_only:
+            print(".", end="", flush=True)
+        else:
+            print(pr.summary)
 
     if cli_config.back:
+        if cli_config.compare_only:
+            print("\n")
         compare_results(target_prs)
 
 

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -5,6 +5,9 @@ from . import profile_utils, analysis_utils, summary_utils
 from . import flags
 from .cli_config import cli_config
 
+from rich.console import Console
+from rich.table import Table
+
 
 def process_data(target_prs):
     """Process a list of PRs.
@@ -34,28 +37,29 @@ def process_data(target_prs):
     if cli_config.back:
         compare_results(target_prs)
 
+
 def compare_results(target_prs):
     """Compare gh-profiler results with final merged state."""
-    comparison = "Comparison of gh-profiler results with final merged state:\n"
-    comparison += "\nPR num | Merged/closed | author | gh-profiler flags | PR link\n"
-    for pr in target_prs:
-        comparison += f"{pr.pr_num} | "
-        
-        if pr.merged:
-            comparison += f"{flags.merged_flag} | "
-        else:
-            comparison += f"{flags.red_flag} | "
+    table = Table(title="Comparison of gh-profiler results with final merged state:")
 
-        comparison += f"{pr.author} | "
+    table.add_column("PR num")
+    table.add_column("Merged/closed")
+    table.add_column("Author")
+    table.add_column("gh-profiler flags")
+    table.add_column("PR link")
+
+    for pr in target_prs:
+        if pr.merged:
+            merged_flag = flags.merged_flag
+        else:
+            merged_flag = flags.red_flag
         
         profile_flags = " ".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
-        comparison += f"{profile_flags} | "
 
-        comparison += f"{pr.url}\n"
+        table.add_row(str(pr.pr_num), merged_flag, pr.author, profile_flags, pr.url)
 
-    print(comparison)
-
-
+    console = Console()
+    console.print(table)
 
         
 def _adjust_author_summary(summary):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -42,10 +42,10 @@ def compare_results(target_prs):
     """Compare gh-profiler results with final merged state."""
     table = Table(title="Comparison of gh-profiler results with final merged state:")
 
-    table.add_column("PR num")
-    table.add_column("Merged/closed")
+    table.add_column("PR num", justify="center")
+    table.add_column("Merged?", justify="center")
     table.add_column("Author")
-    table.add_column("gh-profiler flags")
+    table.add_column("gh-profiler")
     table.add_column("PR link")
 
     for pr in target_prs:

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -32,6 +32,9 @@ def process_data(target_prs):
         # DEV: Print the summary here while we're not doing this in parallel.
         # When these are being processed in parallel, we'll remove this line
         # and call show_summary() from gh_profiler.
+        # Also, redacting here for now.
+        if cli_config.redact:
+            pr.author = "<redacted>"
         print(pr.summary)
 
     if cli_config.back:

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -16,7 +16,7 @@ def process_data(target_prs):
     Calls gh-profiler on each PR author.
     Evaluates results.
     """
-    if cli_config.compare_only:
+    if cli_config.table_only:
         print("Fetching user profiles ", end="", flush=True)
         
     for pr in target_prs:
@@ -45,13 +45,13 @@ def process_data(target_prs):
         if cli_config.redact:
             pr.author = "<redacted>"
 
-        if cli_config.back and cli_config.compare_only:
+        if cli_config.back and cli_config.table_only:
             print(".", end="", flush=True)
         else:
             print(pr.summary)
 
     if cli_config.back:
-        if cli_config.compare_only:
+        if cli_config.table_only:
             print("\n")
         compare_results(target_prs)
 

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -23,10 +23,13 @@ def process_data(target_prs):
         # Get concise gh-profiler output for PR author.
         pdata.reset_fields()
         pdata.username = pr.author
-        profile_utils.get_data()
-        analysis_utils.process_data()
 
-        pr.author_summary = summary_utils._get_concise_summary()
+        if author_summary := _get_cached_author_summary(pdata.username, target_prs):
+            pr.author_summary = author_summary
+        else:
+            profile_utils.get_data()
+            analysis_utils.process_data()
+            pr.author_summary = summary_utils._get_concise_summary()
 
         pr.summary = _get_pr_summary(pr, pr.author_summary)
 
@@ -50,6 +53,15 @@ def process_data(target_prs):
         if cli_config.compare_only:
             print("\n")
         compare_results(target_prs)
+
+def _get_cached_author_summary(username, target_prs):
+    """Get an existing author summary if it's already been built."""
+    author_prs = [pr for pr in target_prs if pr.author == username]
+
+    for pr in author_prs:
+        if pr.author_summary:
+            return pr.author_summary
+
 
 
 def compare_results(target_prs):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -32,8 +32,11 @@ def _adjust_author_summary(summary):
     - Indent lines
     """
     lines = summary.splitlines()
-    # Remove "For a more detailed report..."
-    lines = lines[:-2]
+
+    if pdata.username != "ghost":
+        # Remove "For a more detailed report..."
+        lines = lines[:-2]
+        
     # Indent lines.
     lines = [f"  {l}" for l in lines]
 

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -30,7 +30,8 @@ def process_data(target_prs):
         # and call show_summary() from gh_profiler.
         print(pr.summary)
 
-    compare_results(target_prs)
+    if cli_config.back:
+        compare_results(target_prs)
 
 def compare_results(target_prs):
     """Compare gh-profiler results with final merged state."""

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -45,15 +45,14 @@ def process_data(target_prs):
         if cli_config.redact:
             pr.author = "<redacted>"
 
-        if cli_config.back and cli_config.table_only:
+        if cli_config.table_only:
             print(".", end="", flush=True)
         else:
             print(pr.summary)
 
-    if cli_config.back:
-        if cli_config.table_only:
-            print("\n")
-        compare_results(target_prs)
+    if cli_config.table_only:
+        print("\n")
+    show_table(target_prs)
 
 def _get_cached_author_info(username, target_prs):
     """Get an existing author summary if it's already been built."""
@@ -69,25 +68,33 @@ def _get_cached_author_info(username, target_prs):
             )
 
 
-def compare_results(target_prs):
-    """Compare gh-profiler results with final merged state."""
+def show_table(target_prs):
+    """Show table of results.
+    
+    If looking back, show final merged state as well.
+    """
     table = Table(title="Comparison of gh-profiler results with final merged state:")
 
     table.add_column("PR num", justify="center")
-    table.add_column("Merged?", justify="center")
+    if cli_config.back:
+        table.add_column("Merged?", justify="center")
     table.add_column("Author")
     table.add_column("gh-profiler")
     table.add_column("PR link", no_wrap=True)
 
     for pr in target_prs:
-        if pr.merged:
-            merged_flag = flags.merged_flag
-        else:
-            merged_flag = flags.red_flag
+        if cli_config.back:
+            if pr.merged:
+                merged_flag = flags.merged_flag
+            else:
+                merged_flag = flags.red_flag
         
         profile_flags = " ".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
 
-        table.add_row(str(pr.pr_num), merged_flag, pr.author, profile_flags, pr.url)
+        if cli_config.back:
+            table.add_row(str(pr.pr_num), merged_flag, pr.author, profile_flags, pr.url)
+        else:
+            table.add_row(str(pr.pr_num), pr.author, profile_flags, pr.url)
 
     console = Console()
     console.print(table)

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -21,10 +21,37 @@ def process_data(target_prs):
         author_summary = summary_utils._get_concise_summary()
         pr.summary = _get_pr_summary(pr, author_summary)
 
+        pr.profile_flag = pdata.flag_overall_profile
+        pr.pr_flag = pdata.flag_overall_pr
+        pr.issue_flag = pdata.flag_overall_issues
+
         # DEV: Print the summary here while we're not doing this in parallel.
         # When these are being processed in parallel, we'll remove this line
         # and call show_summary() from gh_profiler.
         print(pr.summary)
+
+    compare_results(target_prs)
+
+def compare_results(target_prs):
+    """Compare gh-profiler results with final merged state."""
+    comparison = "Comparison of gh-profiler results with final merged state:\n"
+    comparison += "\nPR num | Merged/closed | gh-profiler flags | PR link\n"
+    for pr in target_prs:
+        comparison += f"{pr.pr_num} | "
+        
+        if pr.merged:
+            comparison += f"{flags.merged_flag} | "
+        else:
+            comparison += f"{flags.red_flag} | "
+        
+        profile_flags = " ".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
+        comparison += f"{profile_flags} | "
+
+        comparison += f"{pr.url}\n"
+
+    print(comparison)
+
+
 
         
 def _adjust_author_summary(summary):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -15,6 +15,7 @@ def process_data(target_prs):
     """
     for pr in target_prs:
         # Get concise gh-profiler output for PR author.
+        pdata.reset_fields()
         pdata.username = pr.author
         profile_utils.get_data()
         analysis_utils.process_data()
@@ -36,7 +37,7 @@ def process_data(target_prs):
 def compare_results(target_prs):
     """Compare gh-profiler results with final merged state."""
     comparison = "Comparison of gh-profiler results with final merged state:\n"
-    comparison += "\nPR num | Merged/closed | gh-profiler flags | PR link\n"
+    comparison += "\nPR num | Merged/closed | author | gh-profiler flags | PR link\n"
     for pr in target_prs:
         comparison += f"{pr.pr_num} | "
         
@@ -44,6 +45,8 @@ def compare_results(target_prs):
             comparison += f"{flags.merged_flag} | "
         else:
             comparison += f"{flags.red_flag} | "
+
+        comparison += f"{pr.author} | "
         
         profile_flags = " ".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
         comparison += f"{profile_flags} | "

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -94,7 +94,7 @@ def show_table(target_prs):
         if cli_config.back:
             table.add_row(str(pr.pr_num), merged_flag, profile_flags, pr.author, pr.url)
         else:
-            table.add_row(str(pr.pr_num), pr.author, profile_flags, pr.url)
+            table.add_row(str(pr.pr_num), profile_flags, pr.author, pr.url)
 
     console = Console()
     console.print(table)

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -46,7 +46,7 @@ def compare_results(target_prs):
     table.add_column("Merged?", justify="center")
     table.add_column("Author")
     table.add_column("gh-profiler")
-    table.add_column("PR link")
+    table.add_column("PR link", no_wrap=True)
 
     for pr in target_prs:
         if pr.merged:

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -66,7 +66,7 @@ def _get_status_line(pr):
     if not cli_config.back:
         return f"\n{pr.url}\n\n"
     
-    if pr.closed_state == "MERGED":
+    if pr.merged:
         status = f"{flags.merged_flag} Merged."
     else:
         status = f"{flags.red_flag} Closed."

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -48,7 +48,7 @@ def _get_pr_summary(pr, author_summary):
     """Get the summary for an individual PR."""
     author_summary = _adjust_author_summary(author_summary)
 
-    pr_summary = f"PR {pr.pr_num}: {pr.title}"
+    pr_summary = f"PR {pr.pr_num}: {pr.title.strip()}"
     pr_summary += _get_status_line(pr)
     pr_summary += author_summary
     pr_summary += "\n\n"

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -25,8 +25,10 @@ def process_data(target_prs):
         pdata.username = pr.author
         profile_utils.get_data()
         analysis_utils.process_data()
-        author_summary = summary_utils._get_concise_summary()
-        pr.summary = _get_pr_summary(pr, author_summary)
+
+        pr.author_summary = summary_utils._get_concise_summary()
+
+        pr.summary = _get_pr_summary(pr, pr.author_summary)
 
         pr.profile_flag = pdata.flag_overall_profile
         pr.pr_flag = pdata.flag_overall_pr

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -78,8 +78,8 @@ def show_table(target_prs):
     table.add_column("PR num", justify="center")
     if cli_config.back:
         table.add_column("Merged?", justify="center")
-    table.add_column("Author")
     table.add_column("gh-profiler")
+    table.add_column("Author")
     table.add_column("PR link", no_wrap=True)
 
     for pr in target_prs:
@@ -92,7 +92,7 @@ def show_table(target_prs):
         profile_flags = "".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
 
         if cli_config.back:
-            table.add_row(str(pr.pr_num), merged_flag, pr.author, profile_flags, pr.url)
+            table.add_row(str(pr.pr_num), merged_flag, profile_flags, pr.author, pr.url)
         else:
             table.add_row(str(pr.pr_num), pr.author, profile_flags, pr.url)
 

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -20,6 +20,9 @@ class PRData:
     author: str = ""
     title: str = ""
     url: str = ""
+    
+    closed_state: str = ""
+
 
     # Processed info
     summary: str = ""

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -22,8 +22,8 @@ class PRData:
     title: str = ""
     url: str = ""
     
-    closed_state: str = ""
-    created_at: dt | None = None
+    merged: bool | None = None
+    closed_at: dt | None = None
 
 
     # Processed info

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -1,6 +1,7 @@
 """One place to store all data about the targeted repo."""
 
 from dataclasses import dataclass
+from datetime import datetime as dt, timezone
 
 
 @dataclass(slots=True)
@@ -22,6 +23,7 @@ class PRData:
     url: str = ""
     
     closed_state: str = ""
+    closed_at: dt | None = None
 
 
     # Processed info

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -23,7 +23,7 @@ class PRData:
     url: str = ""
     
     closed_state: str = ""
-    closed_at: dt | None = None
+    created_at: dt | None = None
 
 
     # Processed info

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -29,5 +29,11 @@ class PRData:
     # Processed info
     summary: str = ""
 
+    # User flags
+    # When pdata is not a singleton, we shouldn't need to store these here.
+    profile_flag: str = ""
+    pr_flag: str = ""
+    issue_flag: str = ""
+
 
 repo_data = RepoData()

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -27,6 +27,7 @@ class PRData:
 
 
     # Processed info
+    author_summary: str = ""
     summary: str = ""
 
     # User flags

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -87,18 +87,29 @@ def _parse_prs(prs_obj):
     # and number.
     target_prs = []
     for pr_dict in prs_json["data"]["repository"]["pullRequests"]["nodes"]:
-        breakpoint()
+        # breakpoint()
         pr_data = PRData(
             pr_num=pr_dict["number"],
-            author=pr_dict["author"]["login"],
+            author=_get_author(pr_dict),
             title=pr_dict["title"],
             url=pr_dict["url"],
         )
         if cli_config.back:
             _add_pr_back_fields(pr_dict, pr_data)
         target_prs.append(pr_data)
-    breakpoint()
+    # breakpoint()
     return target_prs
+
+def _get_author(pr_dict):
+    """Get the author of the PR.
+    
+    When a user deletes their account, GitHub shows the author as `ghost`.
+    """
+    if pr_dict["author"] is None:
+        return "ghost"
+    else:
+        return pr_dict["author"]["login"]
+    
 
 
 def _add_pr_back_fields(pr_dict, pr_data):

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -5,6 +5,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from textwrap import dedent
 from time import perf_counter
+from datetime import datetime as dt, timezone
 
 from . import infra_utils
 from .profile_data import profile_data as pdata
@@ -97,7 +98,7 @@ def _parse_prs(prs_obj):
         if cli_config.back:
             _add_pr_back_fields(pr_dict, pr_data)
         target_prs.append(pr_data)
-    # breakpoint()
+    breakpoint()
     return target_prs
 
 def _get_author(pr_dict):
@@ -111,13 +112,21 @@ def _get_author(pr_dict):
         return pr_dict["author"]["login"]
     
 
-
 def _add_pr_back_fields(pr_dict, pr_data):
     """Add fields to PRData object that only related to looking back."""
+    pr_data.closed_at = _parse_gh_timestamp(pr_dict["closedAt"])
+
     if pr_dict["merged"]:
         pr_data.closed_state = "merged"
     else:
         pr_data.closed_state = "closed without merging"
+
+
+def _parse_gh_timestamp(ts):
+    """Parse a gh API timestamp."""
+    return dt.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
 
 
 def _get_pr_query():

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -87,23 +87,36 @@ def _parse_prs(prs_obj):
     # and number.
     target_prs = []
     for pr_dict in prs_json["data"]["repository"]["pullRequests"]["nodes"]:
+        breakpoint()
         pr_data = PRData(
             pr_num=pr_dict["number"],
             author=pr_dict["author"]["login"],
             title=pr_dict["title"],
             url=pr_dict["url"],
         )
+        if cli_config.back:
+            _add_pr_back_fields(pr_dict, pr_data)
         target_prs.append(pr_data)
-
+    breakpoint()
     return target_prs
+
+
+def _add_pr_back_fields(pr_dict, pr_data):
+    """Add fields to PRData object that only related to looking back."""
+    if pr_dict["merged"]:
+        pr_data.closed_state = "merged"
+    else:
+        pr_data.closed_state = "closed without merging"
 
 
 def _get_pr_query():
     """Return the gh call for recent PRs in a repo."""
     if cli_config.back:
         gh_state = "CLOSED"
+        order_field = "UPDATED_AT"
     else:
         gh_state = "OPEN"
+        order_field = "CREATED_AT"
 
     gh_call = f"""
         gh api graphql -f query='

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -45,6 +45,11 @@ def get_data():
     # _parse_reachable(reachable_str)
     target_prs = _parse_prs(prs_obj)
 
+    # Sort PRs by createdAt timestamp. This helps address the fact that gh
+    # typically returns PR data based on updated times, not opened times.
+    if cli_config.back:
+        target_prs.sort(key=lambda pr: pr.created_at, reverse=True)
+
     return target_prs
 
 
@@ -98,7 +103,7 @@ def _parse_prs(prs_obj):
         if cli_config.back:
             _add_pr_back_fields(pr_dict, pr_data)
         target_prs.append(pr_data)
-    breakpoint()
+    # breakpoint()
     return target_prs
 
 def _get_author(pr_dict):
@@ -114,7 +119,7 @@ def _get_author(pr_dict):
 
 def _add_pr_back_fields(pr_dict, pr_data):
     """Add fields to PRData object that only related to looking back."""
-    pr_data.closed_at = _parse_gh_timestamp(pr_dict["closedAt"])
+    pr_data.created_at = _parse_gh_timestamp(pr_dict["createdAt"])
 
     if pr_dict["merged"]:
         pr_data.closed_state = "merged"
@@ -127,7 +132,6 @@ def _parse_gh_timestamp(ts):
     return dt.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
         tzinfo=timezone.utc
     )
-
 
 def _get_pr_query():
     """Return the gh call for recent PRs in a repo."""

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -98,20 +98,36 @@ def _parse_prs(prs_obj):
     return target_prs
 
 
-def _get_pr_query():
-    """Return the gh call for recent open PRs in a repo."""
+def _get_pr_query(state="open"):
+    """Return the gh call for recent PRs in a repo."""
+    state = state.lower()
+
+    if state == "open":
+        gh_state = "OPEN"
+        order_field = "CREATED_AT"
+    elif state == "closed":
+        gh_state = "CLOSED"
+        order_field = "UPDATED_AT"
+    else:
+        raise ValueError(f"Unknown PR state: {state}")
+
     gh_call = f"""
         gh api graphql -f query='
         query($owner: String!, $repo: String!, $n: Int!) {{
         repository(owner: $owner, name: $repo) {{
             pullRequests(
             first: $n,
-            states: OPEN,
-            orderBy: {{field: CREATED_AT, direction: DESC}}
+            states: {gh_state},
+            orderBy: {{field: {order_field}, direction: DESC}}
             ) {{
             nodes {{
                 number
                 title
+                state
+                merged
+                createdAt
+                closedAt
+                mergedAt
                 url
                 author {{
                 login

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -88,7 +88,6 @@ def _parse_prs(prs_obj):
     # and number.
     target_prs = []
     for pr_dict in prs_json["data"]["repository"]["pullRequests"]["nodes"]:
-        # breakpoint()
         pr_data = PRData(
             pr_num=pr_dict["number"],
             author=_get_author(pr_dict),
@@ -101,7 +100,6 @@ def _parse_prs(prs_obj):
 
     # When looking back, we grabbed more PRs than we need. Sort them by 
     # closedAt, and return the number that were actually requested.
-    # breakpoint()
     if cli_config.back:
         target_prs.sort(key=lambda pr: pr.closed_at, reverse=True)
         target_prs = target_prs[:cli_config.num_targets]
@@ -123,7 +121,6 @@ def _get_author(pr_dict):
 def _add_pr_back_fields(pr_dict, pr_data):
     """Add fields to PRData object that only related to looking back."""
     pr_data.closed_at = _parse_gh_timestamp(pr_dict["closedAt"])
-    # breakpoint()
 
     if pr_dict["merged"]:
         pr_data.merged = True

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -45,11 +45,6 @@ def get_data():
     # _parse_reachable(reachable_str)
     target_prs = _parse_prs(prs_obj)
 
-    # Sort PRs by createdAt timestamp. This helps address the fact that gh
-    # typically returns PR data based on updated times, not opened times.
-    if cli_config.back:
-        target_prs.sort(key=lambda pr: pr.created_at, reverse=True)
-
     return target_prs
 
 
@@ -103,7 +98,15 @@ def _parse_prs(prs_obj):
         if cli_config.back:
             _add_pr_back_fields(pr_dict, pr_data)
         target_prs.append(pr_data)
+
+    # When looking back, we grabbed more PRs than we need. Sort them by 
+    # closedAt, and return the number that were actually requested.
     # breakpoint()
+    if cli_config.back:
+        target_prs.sort(key=lambda pr: pr.closed_at, reverse=True)
+        target_prs = target_prs[:cli_config.num_targets]
+
+
     return target_prs
 
 def _get_author(pr_dict):
@@ -119,12 +122,13 @@ def _get_author(pr_dict):
 
 def _add_pr_back_fields(pr_dict, pr_data):
     """Add fields to PRData object that only related to looking back."""
-    pr_data.created_at = _parse_gh_timestamp(pr_dict["createdAt"])
+    pr_data.closed_at = _parse_gh_timestamp(pr_dict["closedAt"])
+    # breakpoint()
 
     if pr_dict["merged"]:
-        pr_data.closed_state = "merged"
+        pr_data.merged = True
     else:
-        pr_data.closed_state = "closed without merging"
+        pr_data.merged = False
 
 
 def _parse_gh_timestamp(ts):
@@ -136,11 +140,20 @@ def _parse_gh_timestamp(ts):
 def _get_pr_query():
     """Return the gh call for recent PRs in a repo."""
     if cli_config.back:
-        gh_state = "CLOSED"
+        gh_state = "[CLOSED, MERGED]"
         order_field = "UPDATED_AT"
     else:
         gh_state = "OPEN"
         order_field = "CREATED_AT"
+
+    if cli_config.back:
+        # Get 5x as many PRs as requested. This query is sorted by updatedAt,
+        # We want to show by closedAt.
+        num_prs = 5 * cli_config.num_targets
+    else:
+        # When looking at open PRs, no need to modify count.
+        num_prs = cli_config.num_targets
+
 
     gh_call = f"""
         gh api graphql -f query='
@@ -166,7 +179,7 @@ def _get_pr_query():
             }}
             }}
         }}
-        }}' -F owner='{repo_data.owner}' -F repo='{repo_data.repo_name}' -F n={cli_config.num_targets}
+        }}' -F owner='{repo_data.owner}' -F repo='{repo_data.repo_name}' -F n={num_prs}
     """
 
     return dedent(gh_call).strip()

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -98,18 +98,12 @@ def _parse_prs(prs_obj):
     return target_prs
 
 
-def _get_pr_query(state="open"):
+def _get_pr_query():
     """Return the gh call for recent PRs in a repo."""
-    state = state.lower()
-
-    if state == "open":
-        gh_state = "OPEN"
-        order_field = "CREATED_AT"
-    elif state == "closed":
+    if cli_config.back:
         gh_state = "CLOSED"
-        order_field = "UPDATED_AT"
     else:
-        raise ValueError(f"Unknown PR state: {state}")
+        gh_state = "OPEN"
 
     gh_call = f"""
         gh api graphql -f query='

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -34,6 +34,10 @@ def _get_concise_summary():
 
     This is one line for each main section: name, profile, pr activity, issue activity.
     """
+    if pdata.username == "ghost":
+        # This is GitHub's deleted user, and we don't need to do anything.
+        return f"🔴 The `ghost` account is GitHub's reference to a deleted user."
+        
     if pdata.redact:
         _redact_info()
     

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -16,6 +16,10 @@ def show_summary():
 
 def _get_summary():
     """Build a summary string."""
+    if pdata.username == "ghost":
+        # This is GitHub's deleted user, and we don't need to do anything.
+        return f"🔴 The `ghost` account is GitHub's reference to a deleted user."
+
     if pdata.redact:
         _redact_info()
 

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -154,7 +154,6 @@ def test_bulk_closed_prs():
     output = run_with_timeout(cmd)
 
     assert output.count("https://github.com/django/django/pull/") == 6
-    # If ghost is there, it's there twice.
     assert output.count("GitHub user: ") + output.count("`ghost`") == 3
     assert output.count("Merged.") + output.count("Closed.") == 3
 
@@ -162,6 +161,24 @@ def test_bulk_closed_prs():
     re_pr_title = r"(PR \d+: ).*"
     matches = re.findall(re_pr_title, output)
     assert len(matches) == 3
+
+
+def test_bulk_closed_prs_table_only():
+    """Test a table-only run against a repo URL for bulk processing closed PRs."""
+    # Django is likely to have many closed PRs.
+    url = "https://github.com/django/django"
+    cmd = f"uv run gh-profiler {url} --back -n 3 --table-only"
+    output = run_with_timeout(cmd)
+
+    assert output.count("https://github.com/django/django/pull/") == 3
+    assert "GitHub user: " not in output
+    assert "Merged." not in output
+    assert "Closed." not in output
+
+    # Check that there are no PR numbers and titles in output.
+    re_pr_title = r"(PR \d+: ).*"
+    matches = re.findall(re_pr_title, output)
+    assert len(matches) == 0
 
 
 @pytest.mark.parametrize("mode", ["", "--concise"])

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -146,6 +146,23 @@ def test_bulk_open_prs():
     assert len(matches) == 3
 
 
+def test_bulk_closed_prs():
+    """Test a run against a repo URL for bulk processing closed PRs."""
+    # Django is likely to have many closed PRs.
+    url = "https://github.com/django/django"
+    cmd = f"uv run gh-profiler {url} --back -n 3"
+    output = run_with_timeout(cmd)
+
+    assert output.count("https://github.com/django/django/pull/") == 3
+    assert output.count("GitHub user: ") + output.count("`ghost`") == 3
+    assert output.count("Merged") + output.count("Closed") == 3
+
+    # Check that there are 3 PR numbers and titles in output.
+    re_pr_title = r"(PR \d+: ).*"
+    matches = re.findall(re_pr_title, output)
+    assert len(matches) == 3
+
+
 @pytest.mark.parametrize("mode", ["", "--concise"])
 def test_ghost_profile(mode):
     """Test a run against the `ghost` user.

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -145,3 +145,18 @@ def test_bulk_open_prs():
     matches = re.findall(re_pr_title, output)
     assert len(matches) == 3
 
+
+def test_ghost_profile():
+    """Test a run against the `ghost` user.
+
+    GitHub has a special user account named `ghost` that stands in for
+    deleted users in completed actions, such as closed PRs.
+
+    This should return a single red flag, with an explanation of this role.
+
+    See: https://github.com/ghost
+    """
+    cmd = "uv run gh-profiler ghost --concise"
+    output = run_with_timeout(cmd)
+
+    assert output == f"🔴 The `ghost` account is GitHub's reference to a deleted user."

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -153,9 +153,10 @@ def test_bulk_closed_prs():
     cmd = f"uv run gh-profiler {url} --back -n 3"
     output = run_with_timeout(cmd)
 
-    assert output.count("https://github.com/django/django/pull/") == 3
+    assert output.count("https://github.com/django/django/pull/") == 6
+    # If ghost is there, it's there twice.
     assert output.count("GitHub user: ") + output.count("`ghost`") == 3
-    assert output.count("Merged") + output.count("Closed") == 3
+    assert output.count("Merged.") + output.count("Closed.") == 3
 
     # Check that there are 3 PR numbers and titles in output.
     re_pr_title = r"(PR \d+: ).*"

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -146,7 +146,8 @@ def test_bulk_open_prs():
     assert len(matches) == 3
 
 
-def test_ghost_profile():
+@pytest.mark.parametrize("mode", ["", "--concise"])
+def test_ghost_profile(mode):
     """Test a run against the `ghost` user.
 
     GitHub has a special user account named `ghost` that stands in for
@@ -156,7 +157,7 @@ def test_ghost_profile():
 
     See: https://github.com/ghost
     """
-    cmd = "uv run gh-profiler ghost"
+    cmd = f"uv run gh-profiler ghost {mode}"
     output = run_with_timeout(cmd)
 
     assert output.strip() == f"🔴 The `ghost` account is GitHub's reference to a deleted user."

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -137,7 +137,7 @@ def test_bulk_open_prs():
     cmd = f"uv run gh-profiler {url} -n 3"
     output = run_with_timeout(cmd)
 
-    assert output.count("https://github.com/django/django/pull/") == 3
+    assert output.count("https://github.com/django/django/pull/") == 6
     assert output.count("GitHub user: ") == 3
 
     # Check that there are 3 PR numbers and titles in output.

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -156,7 +156,7 @@ def test_ghost_profile():
 
     See: https://github.com/ghost
     """
-    cmd = "uv run gh-profiler ghost --concise"
+    cmd = "uv run gh-profiler ghost"
     output = run_with_timeout(cmd)
 
-    assert output == f"🔴 The `ghost` account is GitHub's reference to a deleted user."
+    assert output.strip() == f"🔴 The `ghost` account is GitHub's reference to a deleted user."

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -146,6 +146,27 @@ def test_bulk_open_prs():
     assert len(matches) == 3
 
 
+def test_bulk_open_prs_table_only():
+    """Test a table-only run against a repo URL for bulk processing open PRs."""
+    # Django is likely to have many open PRs.
+    url = "https://github.com/django/django"
+    cmd = f"uv run gh-profiler {url} -n 3 --table-only"
+    output = run_with_timeout(cmd)
+
+    assert output.count("https://github.com/django/django/pull/") == 3
+    assert "GitHub user: " not in output
+    assert "Merged." not in output
+    assert "Closed." not in output
+
+    # Make sure Merged? column is not in output for open PRs.
+    assert "Merged?" not in output
+
+    # Check that there are no PR numbers and titles in output.
+    re_pr_title = r"(PR \d+: ).*"
+    matches = re.findall(re_pr_title, output)
+    assert len(matches) == 0
+
+
 def test_bulk_closed_prs():
     """Test a run against a repo URL for bulk processing closed PRs."""
     # Django is likely to have many closed PRs.

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,7 @@ dependencies = [
     { name = "click" },
     { name = "httpx2" },
     { name = "humanize" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -79,6 +80,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "httpx2", specifier = ">=2.3.0" },
     { name = "humanize", specifier = ">=4.15.0" },
+    { name = "rich", specifier = ">=15.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -152,6 +154,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -207,6 +230,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Extends repo target functionality to recently merged and closed PRs. Uses Rich to output a summary table for both. Special case for handling GitHub's `ghost` user. Method to reset pdata instances, while it's being used as a singleton.