### PR TITLE
Fix 127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
-### Unreleased
+### 0.8.1
+
+#### External changes
+
+- Validates `--num-targets` `-n` is no greater than 100.
+- Don't wrap author column in summary table for bulk reporting.
+
+#### Internal changes
+
+- When looking --back, allow n up to 100 but don't request more than 100 records.
+
+### 0.8.0
 
 #### External changes
 

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -55,7 +55,7 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
     $ gh-profiler <repo-url> --back
     $ gh-profiler <repo-url> --back -n 20 --table-only
     """
-    _validate_command(target, concise, generate_workflow, verbose, redact, benchmark_fetch)
+    _validate_command(target, concise, num_targets, generate_workflow, verbose, redact, benchmark_fetch)
 
     # Parse CLI options.
     pdata.concise = concise
@@ -89,7 +89,7 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
         cli_utils.process_pr_issue_num(pr_issue_num)
         gh_profiler.main()
 
-def _validate_command(target, concise, generate_workflow, verbose, redact, benchmark_fetch):
+def _validate_command(target, concise, num_targets, generate_workflow, verbose, redact, benchmark_fetch):
     """Validate arguments that were passed in the CLI call."""
 
     # If target is not passed, --generate-workflow must be passed.
@@ -101,6 +101,11 @@ def _validate_command(target, concise, generate_workflow, verbose, redact, bench
     # If target is passed, --generate-workflow can not be passed.
     if target and generate_workflow:
         msg = "Please either include a target or --generate-workflow, but not both."
+        sys.exit(msg)
+    
+    # For any bulk request, you can request up to 100 records.
+    if num_targets > 100:
+        msg = "You can request up to 100 targets. (-n, --num-targets)"
         sys.exit(msg)
 
 def _parse_repo_options(num_targets, back, redact, table_only):

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -79,7 +79,7 @@ def show_table(target_prs):
     if cli_config.back:
         table.add_column("Merged?", justify="center")
     table.add_column("gh-profiler")
-    table.add_column("Author")
+    table.add_column("Author", no_wrap=True)
     table.add_column("PR link", no_wrap=True)
 
     for pr in target_prs:

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -145,8 +145,10 @@ def _get_pr_query():
 
     if cli_config.back:
         # Get 5x as many PRs as requested. This query is sorted by updatedAt,
-        # We want to show by closedAt.
+        # We want to show by closedAt. Make sure we don't request more than
+        # 100 records.
         num_prs = 5 * cli_config.num_targets
+        num_prs = min(num_prs, 100)
     else:
         # When looking at open PRs, no need to modify count.
         num_prs = cli_config.num_targets


### PR DESCRIPTION
#### External changes

- Validates `--num-targets` `-n` is no greater than 100.
- Don't wrap author column in summary table for bulk reporting.

#### Internal changes

- When looking --back, allow n up to 100 but don't request more than 100 records.