### PR TITLE
Update workflow to link to Actions log with full profile output, and give users choice of which workflow to use

### DIFF
--- a/.github/workflows/profile_contributors.yml
+++ b/.github/workflows/profile_contributors.yml
@@ -30,14 +30,17 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run gh-profiler
+      - name: Run gh-profiler (=== Expand this to see full profile output ===)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Running gh-profiler for: '${{ steps.meta.outputs.login }}'"
           uvx gh-profiler@latest ${{ steps.meta.outputs.login }} --concise > profiler.txt
-          echo "=== gh-profiler output ==="
-          cat profiler.txt
+          echo
+          echo "======================== Full profile ========================="
+          echo
+          uvx gh-profiler@latest ${{ steps.meta.outputs.login }}
+          echo
+          echo "==============================================================="
 
       - name: Comment on issue or PR
         env:
@@ -49,6 +52,8 @@ jobs:
             echo '```text'
             cat profiler.txt
             echo '```'
+            echo
+            echo '<a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}">Full profile</a>'
           } > body.txt
 
           jq -Rs '{body: .}' body.txt > payload.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 These initial releases have usable behavior, but may have some rough edges for some users and use cases.
 
+### 0.8.3
+
+#### External changes
+
+- Workflow for this repo writes full output in Actions log. PR/issue comments include link to the full profile.
+- When running `--generate-workflow`, user gets the choice of an action that writes concise output as a comment, or only writes a link to the profile output in the Actions log.
+- [Demo repo](https://github.com/ehmatthes/workflow_sandbox), where you can open an issue and see both workflows run.
+
+#### Internal changes
+
+- NA
+
 ### 0.8.2
 
 #### External changes

--- a/README.md
+++ b/README.md
@@ -196,32 +196,28 @@ If you see an example of red or yellow flags being raised with no clear indicati
 GitHub Actions
 ---
 
-gh-profiler can write a GitHub Action that will automatically run `gh-profiler --concise` any time a new PR or issue is opened on your project. The output will be written as a comment on the new PR or issue.
+gh-profiler can write a GitHub Action that will automatically run `gh-profiler --concise` any time a new PR or issue is opened on your project. You can choose to have the profile output written as a comment on the new PR or issue, or you can have the workflow only write a link to the Action log containing the profile output.
 
-The `--generate-workflow` flag does this by writing a `profile_contributors.yml` file to `.github/workflows`:
+See a [working demo](https://github.com/ehmatthes/workflow_sandbox), where you can open a new issue and see both kinds of output.
+
+The `--generate-workflow` option asks which kind of workflow you'd like to use, and then writes a `profile_contributors.yml` file to `.github/workflows`:
 
 ```txt
 $ uvx gh-profiler --generate-workflow
-This will generate a GitHub action that will automatically run gh-profiler
-whenever someone opens a new issue or PR in your repository. The profile
-output will be written as a comment on the issue or PR.
+Would you like to write the concise profile output as a comment on each new PR/issue,
+or just write a link to the Actions log containing the profile output?
 
-The workflow will be written at the following location:
-  /.../.github/workflows/profile_contributors.yml
+1) Write concise profile output as a comment.
+2) Only write the link to the Actions log.
 
-Are you sure you want to do this? (y/n) y
-
-The new workflow file was written:
-  /.../.github/workflows/profile_contributors.yml
-
-To start seeing profiles when new issues and PRs are opened:
-- Commit the workflow file to your main branch.
-- Push your main branch to GitHub.
+Workflow type: 
   ...
 ```
 
 > [!NOTE]
-> You don't need Python if you want to run gh-profiler each time a PR or issue is opened in a repository. You can copy the [profiler_contributors.yml](https://github.com/ehmatthes/gh-profiler/blob/main/src/gh_profiler/templates/profile_contributors.yml) file and paste it into your own `.github/workflows/` directory. From that point forward, you'll see a comment on each new PR and issue with a concise summary of the user that opened the PR or issue. [Example](https://github.com/ehmatthes/gh-profiler/issues/67#issuecomment-4492670239)
+> You don't need Python if you want to run gh-profiler each time a PR or issue is opened in a repository. You can copy the [profiler_contributors.yml](https://github.com/ehmatthes/gh-profiler/blob/main/src/gh_profiler/templates/profile_contributors.yml) file or the [profiler_contributors_link_only.yml](https://github.com/ehmatthes/gh-profiler/blob/main/src/gh_profiler/templates/profile_contributors_link_only.yml) file and paste it into your own `.github/workflows/` directory.
+> 
+> From that point forward, you'll see a comment on each new PR and issue with a concise summary of the user that opened the PR or issue or a link to the Actions log containing the profile output. [Example](https://github.com/ehmatthes/gh-profiler/issues/67#issuecomment-4492670239)
 
 Talks & discussion
 ---

--- a/src/gh_profiler/templates/profile_contributors.yml
+++ b/src/gh_profiler/templates/profile_contributors.yml
@@ -30,14 +30,17 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run gh-profiler
+      - name: Run gh-profiler (=== Expand this to see full profile output ===)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Running gh-profiler for: '${{ steps.meta.outputs.login }}'"
           uvx gh-profiler@latest ${{ steps.meta.outputs.login }} --concise > profiler.txt
-          echo "=== gh-profiler output ==="
-          cat profiler.txt
+          echo
+          echo "======================== Full profile ========================="
+          echo
+          uvx gh-profiler@latest ${{ steps.meta.outputs.login }}
+          echo
+          echo "==============================================================="
 
       - name: Comment on issue or PR
         env:
@@ -49,6 +52,8 @@ jobs:
             echo '```text'
             cat profiler.txt
             echo '```'
+            echo
+            echo '<a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}">Full profile</a>'
           } > body.txt
 
           jq -Rs '{body: .}' body.txt > payload.json

--- a/src/gh_profiler/templates/profile_contributors_link_only.yml
+++ b/src/gh_profiler/templates/profile_contributors_link_only.yml
@@ -1,0 +1,64 @@
+# Run gh-profiler against the author of each new issue and PR.
+
+name: Profile contributors
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  profile-author:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: astral-sh/setup-uv@v6
+      - name: Determine target login and issue number
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "login=${{ github.event.issue.user.login }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "login=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run gh-profiler (=== Expand this to see full profile output ===)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uvx gh-profiler@latest ${{ steps.meta.outputs.login }} --concise > profiler.txt
+          echo
+          echo "======================= Concise profile ======================="
+          echo
+          cat profiler.txt
+          echo
+          echo "==============================================================="
+          echo
+          echo 
+          echo "======================== Full profile ========================="
+          echo
+          uvx gh-profiler@latest ${{ steps.meta.outputs.login }}
+          echo
+          echo "==============================================================="
+
+      - name: Comment on issue or PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo '<a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}">Contributor profile</a>'
+          } > body.txt
+
+          jq -Rs '{body: .}' body.txt > payload.json
+
+          gh api \
+            repos/${{ github.repository }}/issues/${{ steps.meta.outputs.number }}/comments \
+            --input payload.json

--- a/src/gh_profiler/utils/workflow_utils.py
+++ b/src/gh_profiler/utils/workflow_utils.py
@@ -74,7 +74,7 @@ def _confirm_write_workflow(path_workflow, workflow_choice):
     else:
         msg = "This will generate a GitHub action that will automatically run gh-profiler"
         msg += "\nwhenever someone opens a new issue or PR in your repository. The profile"
-        msg += "\noutput will be written to the Actions log. A link to the Actions log
+        msg += "\noutput will be written to the Actions log. A link to the Actions log"
         msg += "\nwill be written as a comment on the issue or PR."
 
     msg += "\n\nThe workflow will be written at the following location:"

--- a/src/gh_profiler/utils/workflow_utils.py
+++ b/src/gh_profiler/utils/workflow_utils.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import sys
 import importlib.resources
 
+import click
+
 
 def generate_workflow():
     """Write a profile_contributors.yml workflow file to the user's repo."""
@@ -20,14 +22,15 @@ def _get_workflow_choice():
     They can choose to write profile output as a comment on PRs and issues, 
     or just write a link to the Actions log that contains the profile output.
     """
-    msg = "Would you like to write the concise profile output as a comment,"
+    msg = "Would you like to write the concise profile output as a comment on each new PR/issue,"
     msg += "\nor just write a link to the Actions log containing the profile output?"
     msg += "\n\n1) Write concise profile output as a comment."
     msg += "\n2) Only write the link to the Actions log."
+    msg += "\n\nWorkflow type"
 
     response = ""
     while response not in ("1", "2"):
-        response = click.prompt(msg, default="1")
+        response = click.prompt(msg)
 
         if response not in ("1", "2"):
             msg_invalid = "\nPlease enter 1 or 2."
@@ -68,11 +71,11 @@ def _get_workflow_path():
 def _confirm_write_workflow(path_workflow, workflow_choice):
     """Confirm the user wants the file written to the calculated location."""
     if workflow_choice == "concise_profile":
-        msg = "This will generate a GitHub action that will automatically run gh-profiler"
+        msg = "\n\nThis will generate a GitHub action that will automatically run gh-profiler"
         msg += "\nwhenever someone opens a new issue or PR in your repository. The profile"
         msg += "\noutput will be written as a comment on the issue or PR."
     else:
-        msg = "This will generate a GitHub action that will automatically run gh-profiler"
+        msg = "\n\nThis will generate a GitHub action that will automatically run gh-profiler"
         msg += "\nwhenever someone opens a new issue or PR in your repository. The profile"
         msg += "\noutput will be written to the Actions log. A link to the Actions log"
         msg += "\nwill be written as a comment on the issue or PR."

--- a/src/gh_profiler/utils/workflow_utils.py
+++ b/src/gh_profiler/utils/workflow_utils.py
@@ -7,10 +7,37 @@ import importlib.resources
 
 def generate_workflow():
     """Write a profile_contributors.yml workflow file to the user's repo."""
+    workflow_choice = _get_workflow_choice()
+
     path = _get_workflow_path()
-    _confirm_write_workflow(path)
-    _write_workflow(path)
+    _confirm_write_workflow(path, workflow_choice)
+    _write_workflow(path, workflow_choice)
     _show_closing_message(path)
+
+def _get_workflow_choice():
+    """Prompt the user for the kind of workflow they'd like to generate.
+
+    They can choose to write profile output as a comment on PRs and issues, 
+    or just write a link to the Actions log that contains the profile output.
+    """
+    msg = "Would you like to write the concise profile output as a comment,"
+    msg += "\nor just write a link to the Actions log containing the profile output?"
+    msg += "\n\n1) Write concise profile output as a comment."
+    msg += "\n2) Only write the link to the Actions log."
+
+    response = ""
+    while response not in ("1", "2"):
+        response = click.prompt(msg, default="1")
+
+        if response not in ("1", "2"):
+            msg_invalid = "\nPlease enter 1 or 2."
+            click.echo(msg_invalid)
+
+    if response == "1":
+        return "concise_profile"
+    else:
+        return "link_only"
+
 
 def _get_workflow_path():
     """Determine the path we'd like to write the workflow to."""
@@ -38,11 +65,18 @@ def _get_workflow_path():
     # No conflicts found. Note that .github/workflows/ may not exist.
     return path_pc_workflow
 
-def _confirm_write_workflow(path_workflow):
+def _confirm_write_workflow(path_workflow, workflow_choice):
     """Confirm the user wants the file written to the calculated location."""
-    msg = "This will generate a GitHub action that will automatically run gh-profiler"
-    msg += "\nwhenever someone opens a new issue or PR in your repository. The profile"
-    msg += "\noutput will be written as a comment on the issue or PR."
+    if workflow_choice == "concise_profile":
+        msg = "This will generate a GitHub action that will automatically run gh-profiler"
+        msg += "\nwhenever someone opens a new issue or PR in your repository. The profile"
+        msg += "\noutput will be written as a comment on the issue or PR."
+    else:
+        msg = "This will generate a GitHub action that will automatically run gh-profiler"
+        msg += "\nwhenever someone opens a new issue or PR in your repository. The profile"
+        msg += "\noutput will be written to the Actions log. A link to the Actions log
+        msg += "\nwill be written as a comment on the issue or PR."
+
     msg += "\n\nThe workflow will be written at the following location:"
     msg += f"\n  {path_workflow.as_posix()}"
     msg += "\n\nAre you sure you want to do this? (y/n) "
@@ -55,11 +89,14 @@ def _confirm_write_workflow(path_workflow):
         elif confirmed.lower() in ("n", "no"):
             sys.exit()
 
-def _write_workflow(path_workflow):
+def _write_workflow(path_workflow, workflow_choice):
     """Write the workflow file to the correct location."""
     # Read source file.
     path_templates = importlib.resources.files("gh_profiler") / "templates"
-    path_src = path_templates / "profile_contributors.yml"
+    if workflow_choice == "concise_profile":
+        path_src = path_templates / "profile_contributors.yml"
+    else:
+        path_src = path_templates / "profile_contributors_link_only.yml"
     contents = path_src.read_text()
 
     # Make .github/workflows dirs as needed.


### PR DESCRIPTION
#### External changes

- Workflow for this repo writes full output in Actions log. PR/issue comments include link to the full profile.
- When running `--generate-workflow`, user gets the choice of an action that writes concise output as a comment, or only writes a link to the profile output in the Actions log.
- [Demo repo](https://github.com/ehmatthes/workflow_sandbox), where you can open an issue and see both workflows run.