### PR TITLE
Handle `https://github.com/username` links as a user profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ GitHub user: <redacted>
 For a more detailed report, run `gh-profiler <redacted>`.
 ```
 
+You can pass either a bare username (`<redacted>`) or a full profile URL (`https://github.com/<redacted>`) as the target.
+
 This is the concise output, which gives you a quick sense of whether the user has any recent activity that indicates problematic open source behavior.
 
 The full output gives you much more specific information:

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -31,11 +31,12 @@ from .utils.cli_config import cli_config
 def main(target, concise, num_targets, back, table_only, generate_workflow, verbose, redact, benchmark_fetch):
     """Examine a GitHub user's profile, to help quickly decide how much to invest in their contributions.
 
-    You can target a GitHub username, or a PR/issue number from the repository you're working in.
+    You can target a GitHub username, a profile URL, or a PR/issue number from the repository you're working in.
 
     \b
     Usage as a tool:
     $ uvx gh-profiler ehmatthes
+    $ uvx gh-profiler https://github.com/ehmatthes
     $ uvx gh-profiler 8
 
     \b
@@ -69,8 +70,15 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
         gh_profiler.main()
         sys.exit()
 
-    # Check if we're processing a repo URL.
+    # Check if we're processing a GitHub URL.
     if "github.com" in target:
+        # A profile URL (https://github.com/octocat) has only an owner and
+        # no repo, so treat it as a username target.
+        username = _parse_profile_url(target)
+        if username:
+            pdata.username = username
+            gh_profiler.main()
+
         cli_config.url = target
         _parse_repo_options(num_targets, back, redact, table_only)
         _parse_repo_info(target)
@@ -107,6 +115,22 @@ def _validate_command(target, concise, num_targets, generate_workflow, verbose, 
     if num_targets > 100:
         msg = "You can request up to 100 targets. (-n, --num-targets)"
         sys.exit(msg)
+
+
+def _parse_profile_url(target):
+    """Return the username if target is a profile URL, else None.
+
+    A profile URL (https://github.com/octocat) has only an owner and no
+    repo name. A repo URL (https://github.com/octocat/Hello-World) has
+    both, in which case we return None.
+    """
+    parsed_url = urlparse(target)
+    # Drop empty segments from leading/trailing slashes.
+    url_parts = [part for part in parsed_url.path.split("/") if part]
+    if len(url_parts) == 1:
+        return url_parts[0]
+    return None
+
 
 def _parse_repo_options(num_targets, back, redact, table_only):
     """Get options relevant to targeting a repo URL."""

--- a/tests/unit_tests/test_parse_profile_url.py
+++ b/tests/unit_tests/test_parse_profile_url.py
@@ -1,0 +1,30 @@
+"""Tests for distinguishing profile URLs from repo URLs."""
+
+import pytest
+
+from gh_profiler.cli import _parse_profile_url
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://github.com/octocat", "octocat"),
+        ("https://github.com/octocat/", "octocat"),
+    ],
+)
+def test_profile_url_returns_username(url, expected):
+    """A profile URL (owner only) returns the username."""
+    assert _parse_profile_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/octocat/Hello-World",
+        "https://github.com/octocat/Hello-World/",
+        "https://github.com/octocat/Hello-World/pull/1",
+    ],
+)
+def test_repo_url_returns_none(url):
+    """A repo URL (owner and repo) returns None."""
+    assert _parse_profile_url(url) is None


### PR DESCRIPTION
It's sometimes convenient to copy and paste a users profile URL to the command line.

Before:

```pytb
❯ uvx gh-profiler https://github.com/octocat
Traceback (most recent call last):
  File "/Users/hugo/.cache/uv/archive-v0/Ere1w6UnNxKNhhqG/bin/gh-profiler", line 12, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/hugo/.cache/uv/archive-v0/Ere1w6UnNxKNhhqG/lib/python3.15/site-packages/click/core.py", line 1524, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/Ere1w6UnNxKNhhqG/lib/python3.15/site-packages/click/core.py", line 1445, in main
    rv = self.invoke(ctx)
  File "/Users/hugo/.cache/uv/archive-v0/Ere1w6UnNxKNhhqG/lib/python3.15/site-packages/click/core.py", line 1308, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/Ere1w6UnNxKNhhqG/lib/python3.15/site-packages/click/core.py", line 877, in invoke
    return callback(*args, **kwargs)
  File "/Users/hugo/.cache/uv/archive-v0/Ere1w6UnNxKNhhqG/lib/python3.15/site-packages/gh_profiler/cli.py", line 76, in main
    _parse_repo_info(target)
    ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/hugo/.cache/uv/archive-v0/Ere1w6UnNxKNhhqG/lib/python3.15/site-packages/gh_profiler/cli.py", line 127, in _parse_repo_info
    repo_data.repo_name = url_parts[2]
                          ~~~~~~~~~^^^
IndexError: list index out of range
```

After:

```console
❯ gh-profiler https://github.com/octocat
GitHub user: octocat
🟢 No concerns found with user's profile.
   🟢 Account age: 15 years
   🟢 Profile information:
        name: The Octocat
        company: @github
        blog: https://github.blog
        location: San Francisco
        email: octocat@github.com
      Empty fields: bio

🟢 No concerns found with recent PR activity.
   🟢 No PRs opened in the last 21 days.

🟢 No concerns found with recent issue activity.
   🟢 No new issues opened in the last 21 days.
```

