### PR TITLE
Add `-h` to Click as an alias for `--help`

### DIFF
--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -12,7 +12,7 @@ from .utils.repo_data import repo_data
 from .utils.cli_config import cli_config
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("target", required=False)
 @click.version_option(package_name="gh-profiler")
 @click.option("--concise", is_flag=True, help="Show concise output; one flag per category.")


### PR DESCRIPTION
The annoying thing about Click:

```console
❯ uvx gh-profiler -h
Usage: gh-profiler [OPTIONS] [TARGET]
Try 'gh-profiler --help' for help.

Error: No such option '-h'.
```


After:

```console
❯ gh-profiler -h
Usage: gh-profiler [OPTIONS] [TARGET]

  Examine a GitHub user's profile, to help quickly decide how much to invest
  in their contributions.

  You can target a GitHub username, or a PR/issue number from the repository
  you're working in.

  Usage as a tool:
  $ uvx gh-profiler ehmatthes
  $ uvx gh-profiler 8

  Usage when installing gh-profiler:
  $ gh-profiler ehmatthes
  $ python -m gh_profiler ehmatthes
    ...

  Bulk concise profiling of most recently opened PRs:
  $ gh-profiler <repo-url>  # 10 most recent PRs
  $ gh-profiler <repo-url> -n 3
  $ gh-profiler <repo-url> --table-only

  Look back at most recently merged/closed PRs:
  $ gh-profiler <repo-url> --back
  $ gh-profiler <repo-url> --back -n 20 --table-only

Options:
  --version                  Show the version and exit.
  --concise                  Show concise output; one flag per category.
  -n, --num-targets INTEGER  Preview: How many PRs to review?
  --back                     Look back over recently merged and closed PRs.
  --table-only               For bulk processing, only show comparison table.
  --generate-workflow        Generate a workflow that will automatically run
                             `gh-profiler --concise` for every new PR and
                             issue.
  -v, --verbose              Verbose output, including explanations for
                             decisions about flags.
  --redact                   Redact identifying information.
  --benchmark-fetch          Benchmark the code that fetches external data.
  -h, --help                 Show this message and exit.
```

---

Alternatively, using argparse has `-h` built in, and has colour help:

<details>
<summary>Details</summary>

<table>
<tr>
<th>Before
<th>After
<tr>
<td valign="top">
<img width="575" height="675" alt="image" src="https://github.com/user-attachments/assets/03f47e07-ccbf-438d-9534-94b62d9e8c1e" />

<td valign="top">
<img width="590" height="765" alt="image" src="https://github.com/user-attachments/assets/7afdd6d6-a516-427e-9b54-0bd78fc82222" />

</table>

Something like https://github.com/ehmatthes/gh-profiler/compare/main...hugovk:gh-profiler:argparse?expand=1 (not fully tested).

</details>
