### PR TITLE
ci: update setup-uv to v9

### DIFF
--- a/.github/workflows/profile_contributors.yml
+++ b/.github/workflows/profile_contributors.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Determine target login and issue number
         id: meta
         env:

--- a/src/gh_profiler/templates/profile_contributors.yml
+++ b/src/gh_profiler/templates/profile_contributors.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Determine target login and issue number
         id: meta
         env:

--- a/src/gh_profiler/templates/profile_contributors_link_only.yml
+++ b/src/gh_profiler/templates/profile_contributors_link_only.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Determine target login and issue number
         id: meta
         env:


### PR DESCRIPTION
## Summary

- update the `setup-uv` pin to v9.0.0 in both generated workflow templates
- regenerate this repository's contributor-profiling workflow with the same pin
- keep the action pinned to the v9.0.0 commit SHA

## Validation

- `uv run pytest tests/integration_tests/test_workflows.py -q` (2 passed)
- `uv run zizmor .github/workflows/profile_contributors.yml --offline --quiet` (no findings; existing suppressions retained)
- `git diff --check`

## Not run locally

- live workflow execution in a separate GitHub repository; this requires a GitHub Actions event

Fixes #147
