### PR TITLE
Readability pass on gh-profiler core modules

### DIFF
--- a/developer_resources/benchmark.py
+++ b/developer_resources/benchmark.py
@@ -18,11 +18,11 @@ $ uv run developer_resources/benchmark.py
 $ uv run developer_resources/benchmark.py <target>
 """
 
-from time import perf_counter
 import shlex
-import subprocess
 import statistics
+import subprocess
 import sys
+from time import perf_counter
 
 # Benchmark against any target.
 try:
@@ -46,7 +46,7 @@ while len(run_times) < 5:
     except subprocess.TimeoutExpired:
         print("Failed run, timed out.")
         continue
-        
+
     # The run was faster than the cutoff time, so keep it.
     ts_end = perf_counter()
     run_time = round((ts_end - ts_start), 2)

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -30,18 +30,17 @@ with this command:
     uv run pytest developer_resources/test_actual_users.py -rs
 """
 
-from pathlib import Path
-import tomllib
-import subprocess
 import os
+import subprocess
+import tomllib
+from pathlib import Path
 
 import pytest
 
-from gh_profiler.utils import infra_utils
-from gh_profiler.utils import flags
-
+from gh_profiler.utils import flags, infra_utils
 
 # --- Helper functions ---
+
 
 def get_users(category):
     """Return data object containing green and non-green user lists."""
@@ -51,18 +50,19 @@ def get_users(category):
     else:
         path_src_dir = Path(__file__).parents[2]
         path = path_src_dir / "gh-profiler_support" / "actual_users.toml"
-    
+
     if not path.exists():
         msg = f"No actual_users.toml file found. Tried {path}"
         pytest.skip(msg, allow_module_level=True)
 
     with path.open("rb") as f:
         data = tomllib.load(f)
-    
+
     if category == "green":
         return data["green_users"]
-    elif category == "non_green":
+    if category == "non_green":
         return data["non_green_users"]
+
 
 def run_with_timeout(cmd):
     """Run gh-profiler command, with a timeout."""
@@ -78,11 +78,10 @@ def run_with_timeout(cmd):
             # Did not time out, but check that we got a response.
             if output:
                 return output
-            else:
-                print("Got an empty response.")
-                num_attempts += 1
-                continue
-    
+            print("Got an empty response.")
+            num_attempts += 1
+            continue
+
     msg = "Too many timeouts."
     pytest.exit(msg)
 
@@ -101,6 +100,7 @@ def test_green_users(username):
 
     assert flags.yellow_flag not in output
     assert flags.red_flag not in output
+
 
 @pytest.mark.parametrize("username", get_users("non_green"))
 def test_non_green_users(username):

--- a/src/gh_profiler/__main__.py
+++ b/src/gh_profiler/__main__.py
@@ -2,6 +2,5 @@
 
 from .cli import main
 
-
 if __name__ == "__main__":
     main()

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -7,9 +7,9 @@ import click
 
 from . import gh_profiler
 from .utils import cli_utils
+from .utils.cli_config import cli_config
 from .utils.profile_data import profile_data as pdata
 from .utils.repo_data import repo_data
-from .utils.cli_config import cli_config
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -97,6 +97,7 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
         cli_utils.process_pr_issue_num(pr_issue_num)
         gh_profiler.main()
 
+
 def _validate_command(target, concise, num_targets, generate_workflow, verbose, redact, benchmark_fetch):
     """Validate arguments that were passed in the CLI call."""
 
@@ -110,7 +111,7 @@ def _validate_command(target, concise, num_targets, generate_workflow, verbose, 
     if target and generate_workflow:
         msg = "Please either include a target or --generate-workflow, but not both."
         sys.exit(msg)
-    
+
     # For any bulk request, you can request up to 100 records.
     if num_targets > 100:
         msg = "You can request up to 100 targets. (-n, --num-targets)"
@@ -139,6 +140,7 @@ def _parse_repo_options(num_targets, back, redact, table_only):
     cli_config.back = back
     cli_config.redact = redact
     cli_config.table_only = table_only
+
 
 def _parse_repo_info(target):
     """Parse info about the repo from the target.

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -6,12 +6,15 @@ to invest in reviewing PRs, and general interaction on open source projects.
 
 import sys
 
+from .utils import (
+    analysis_utils,
+    profile_utils,
+    repo_analysis,
+    repo_fetching,
+    summary_utils,
+    workflow_utils,
+)
 from .utils.profile_data import profile_data as pdata
-from .utils import profile_utils
-from .utils import analysis_utils
-from .utils import workflow_utils
-from .utils import summary_utils
-from .utils import repo_fetching, repo_analysis, repo_summary
 
 
 def main():
@@ -32,6 +35,7 @@ def main():
 
     # Don't return to cli.
     sys.exit()
+
 
 def profile_url():
     """Profile contributors of PRs or issues on a specific repo.

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -1,10 +1,10 @@
 """Utils for analyzing account information."""
 
-from datetime import datetime as dt, timezone
-from datetime import timezone as tz
+from datetime import UTC
+from datetime import datetime as dt
 
-from .profile_data import profile_data as pdata
 from . import flags
+from .profile_data import profile_data as pdata
 
 
 def process_data():
@@ -13,7 +13,7 @@ def process_data():
         # This is GitHub's deleted user, and we don't need to do anything.
         pdata.flag_overall_profile = flags.red_flag
         return
-        
+
     _process_account_age()
     _process_profile_info()
     _process_pr_activity()
@@ -37,9 +37,9 @@ def _process_account_age():
         ts_created = dt.strptime(
             pdata.profile_dict["created_at"],
             "%Y-%m-%dT%H:%M:%SZ",
-        ).replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=UTC)
 
-    pdata.account_age = dt.now(tz.utc) - ts_created
+    pdata.account_age = dt.now(UTC) - ts_created
 
     if pdata.account_age.days > 3 * 365:
         pdata.flag_age = flags.green_flag
@@ -162,6 +162,7 @@ def _set_overall_flags():
     _process_pr_flags()
     _process_issue_flags()
 
+
 def _process_profile_flags():
     """Determine a flag for the overall profile section."""
     profile_flags = (
@@ -169,6 +170,7 @@ def _process_profile_flags():
         pdata.flag_profile,
     )
     pdata.flag_overall_profile = _get_overall_flag(profile_flags)
+
 
 def _process_pr_flags():
     """Determine a flag for the overall PR section."""
@@ -179,6 +181,7 @@ def _process_pr_flags():
     )
     pdata.flag_overall_pr = _get_overall_flag(pr_flags)
 
+
 def _process_issue_flags():
     """Determine a flag for the overall issue section."""
     issues_flags = (
@@ -186,6 +189,7 @@ def _process_issue_flags():
         pdata.flag_repeated_issues,
     )
     pdata.flag_overall_issues = _get_overall_flag(issues_flags)
+
 
 def _get_overall_flag(component_flags):
     """Get an overall flag based on individual flags from a section.
@@ -199,6 +203,7 @@ def _get_overall_flag(component_flags):
     if flags.yellow_flag in component_flags:
         return flags.yellow_flag
     return flags.green_flag
+
 
 def _adjust_flags():
     """Make final adjustments to flags.
@@ -217,6 +222,7 @@ def _adjust_flags():
     """
     _adjust_account_age_flag()
     _adjust_profile_flag_no_pr_issue_activity()
+
 
 def _adjust_account_age_flag():
     """Reevaluate the account age flag.
@@ -244,6 +250,7 @@ def _adjust_account_age_flag():
     msg += "\n  but they have no other concerning activity."
     if pdata.verbose:
         print(msg)
+
 
 def _adjust_profile_flag_no_pr_issue_activity():
     """If user has no recent PRs or issues, profile flags should be green.

--- a/src/gh_profiler/utils/cli_utils.py
+++ b/src/gh_profiler/utils/cli_utils.py
@@ -3,7 +3,6 @@
 import json
 import sys
 
-
 from .infra_utils import run_cmd
 from .profile_data import profile_data as pdata
 
@@ -13,9 +12,7 @@ def process_pr_issue_num(pr_issue_num):
     repo_slug = _get_repo_slug()
 
     # Try as a PR, then as an issue.
-    if username := _process_pr(pr_issue_num, repo_slug):
-        pdata.username = username
-    elif username := _process_issue(pr_issue_num, repo_slug):
+    if (username := _process_pr(pr_issue_num, repo_slug)) or (username := _process_issue(pr_issue_num, repo_slug)):
         pdata.username = username
     else:
         msg = f"Couldn't find a PR or issue #{pr_issue_num} in the repository {repo_slug}."
@@ -29,7 +26,7 @@ def _get_repo_slug():
     """Ask `gh` for the resolved default repo (honors `gh repo set-default`)."""
     result = run_cmd("gh repo view --json nameWithOwner --jq .nameWithOwner")
     output = result.stdout.strip()
-    
+
     if not result.stdout:
         msg = (
             "Couldn't determine the default GitHub repository. "

--- a/src/gh_profiler/utils/infra_utils.py
+++ b/src/gh_profiler/utils/infra_utils.py
@@ -5,12 +5,12 @@ import shlex
 import subprocess
 from dataclasses import dataclass
 
-
 DEFAULT_ENV = {
     **os.environ,
     "CLICOLOR_FORCE": "0",
     "NO_COLOR": "1",
 }
+
 
 @dataclass
 class CommandResult:

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -1,6 +1,6 @@
 """One place to store all data about the user."""
 
-from dataclasses import dataclass, fields, MISSING
+from dataclasses import MISSING, dataclass, fields
 
 
 @dataclass(slots=True)
@@ -108,8 +108,6 @@ class ProfileData:
                 value = field.default
 
             setattr(self, field.name, value)
-
-
 
 
 profile_data = ProfileData()

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -2,13 +2,12 @@
 
 import json
 import sys
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, timedelta
 from datetime import datetime as dt
-from datetime import timedelta
-from datetime import timezone as tz
 from textwrap import dedent
 from time import perf_counter
-from collections import Counter
 
 from . import infra_utils
 from .profile_data import profile_data as pdata
@@ -39,7 +38,7 @@ def get_data():
     if pdata.username == "ghost":
         # This is GitHub's deleted user, and we don't need to do anything.
         return
-        
+
     # Fetch data. This can all be done in parallel. The benchmarking is here
     # because this is the slowest part of the program, and it's helpful at
     # times to benchmark just this fetching code.
@@ -85,6 +84,7 @@ def _fetch_status():
     cmd = "gh auth status"
     return infra_utils.run_cmd(cmd)
 
+
 def _parse_status(status_obj):
     """Parse output of status call.
     
@@ -109,11 +109,13 @@ def _parse_status(status_obj):
         msg += "\nRun `gh auth login` to authenticate."
         sys.exit(msg)
 
+
 def _fetch_profile_dict():
     """Fetch the profile information we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
     result = infra_utils.run_cmd(cmd)
     return result.stdout
+
 
 def _parse_profile_dict(profile_dict_str):
     """Parse the profile information that was fetched."""
@@ -132,6 +134,7 @@ def _parse_profile_dict(profile_dict_str):
     if pdata.profile_dict["created_at"] is None:
         sys.exit(f"GitHub user '{pdata.username}' not found.")
 
+
 def _fetch_orgs():
     """Fetch the user's publicly visible orgs.
     
@@ -146,6 +149,7 @@ def _fetch_orgs():
 
     return result.stdout
 
+
 def _parse_orgs(orgs_str):
     """Parse the org info that was found."""
     try:
@@ -157,6 +161,7 @@ def _parse_orgs(orgs_str):
 
     pdata.orgs = [org["login"] for org in orgs]
 
+
 def _fetch_socials():
     """Fetch social media accounts from user's profile.
     
@@ -167,6 +172,7 @@ def _fetch_socials():
     result = infra_utils.run_cmd(cmd)
 
     return result.stdout
+
 
 def _parse_socials(socials_str):
     """Parse the data string returned from _fetch_socials()."""
@@ -180,7 +186,7 @@ def _parse_socials(socials_str):
 
 def _fetch_pr_activity():
     """Fetch information about recent PR activity."""
-    cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
+    cutoff = (dt.now(UTC) - timedelta(days=21)).date().isoformat()
 
     pr_query = _get_pr_query()
     search_query = (
@@ -190,6 +196,7 @@ def _fetch_pr_activity():
     result = infra_utils.run_cmd(cmd)
 
     return result.stdout
+
 
 def _parse_pr_activity(pr_activity_str):
     """Parse the data returned by _fetch_pr_activity()."""
@@ -234,13 +241,15 @@ def _parse_pr_activity(pr_activity_str):
         pr["state"] == "CLOSED" and pr["mergedAt"] is None for pr in prs_external
     )
 
+
 def _fetch_issue_activity():
     """Fetch target user's recent public issue activity."""
-    cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
+    cutoff = (dt.now(UTC) - timedelta(days=21)).date().isoformat()
     gh_call = _get_gh_issues_call(pdata.username, cutoff)
     result = infra_utils.run_cmd(gh_call)
 
     return result.stdout
+
 
 def _parse_issue_activity(issue_activity_str):
     """Parse data returned by _fetch_issue_activity()."""
@@ -278,6 +287,7 @@ def _parse_issue_activity(issue_activity_str):
     )
 
     _process_repeated_issues(issues_external)
+
 
 def _process_repeated_issues(issues_external):
     """Look for issues with the same title across multiple repositories."""
@@ -329,34 +339,34 @@ def _get_gh_issues_call(username, cutoff):
 
 def _get_pr_query():
     """Return the graphql query for recent PR activity."""
-    pr_query = f"""
-        query($q: String!, $n: Int!) {{
-            search(query: $q, type: ISSUE, first: $n) {{
+    pr_query = """
+        query($q: String!, $n: Int!) {
+            search(query: $q, type: ISSUE, first: $n) {
                 issueCount
-                pageInfo {{
+                pageInfo {
                     hasNextPage
                     endCursor
-                }}
-                nodes {{
-                    ... on PullRequest {{
+                }
+                nodes {
+                    ... on PullRequest {
                         number
                         state
                         createdAt
                         closedAt
                         mergedAt
                         url
-                        repository {{
+                        repository {
                             nameWithOwner
                             isInOrganization
-                            owner {{
+                            owner {
                                 __typename
                                 login
-                            }}
-                        }}
-                    }}
-                }}
-            }}
-        }}
+                            }
+                        }
+                    }
+                }
+            }
+        }
     """
 
     return dedent(pr_query).strip()

--- a/src/gh_profiler/utils/repo_analysis.py
+++ b/src/gh_profiler/utils/repo_analysis.py
@@ -1,12 +1,11 @@
 """Utils for analyzing repo data."""
 
-from .profile_data import profile_data as pdata
-from . import profile_utils, analysis_utils, summary_utils
-from . import flags
-from .cli_config import cli_config
-
 from rich.console import Console
 from rich.table import Table
+
+from . import analysis_utils, flags, profile_utils, summary_utils
+from .cli_config import cli_config
+from .profile_data import profile_data as pdata
 
 
 def process_data(target_prs):
@@ -18,7 +17,7 @@ def process_data(target_prs):
     """
     if cli_config.table_only:
         print("Fetching user profiles ", end="", flush=True)
-        
+
     for pr in target_prs:
         # Get concise gh-profiler output for PR author.
         pdata.reset_fields()
@@ -54,6 +53,7 @@ def process_data(target_prs):
         print("\n")
     show_table(target_prs)
 
+
 def _get_cached_author_info(username, target_prs):
     """Get an existing author summary if it's already been built."""
     author_prs = [pr for pr in target_prs if pr.author == username]
@@ -88,7 +88,7 @@ def show_table(target_prs):
                 merged_flag = flags.merged_flag
             else:
                 merged_flag = flags.red_flag
-        
+
         profile_flags = "".join([pr.profile_flag, pr.pr_flag, pr.issue_flag])
 
         if cli_config.back:
@@ -99,7 +99,7 @@ def show_table(target_prs):
     console = Console()
     console.print(table)
 
-        
+
 def _adjust_author_summary(summary):
     """Modify standard concise output to fit bulk reporting needs.
 
@@ -117,6 +117,7 @@ def _adjust_author_summary(summary):
 
     return "\n".join(lines)
 
+
 def _get_pr_summary(pr, author_summary):
     """Get the summary for an individual PR."""
     author_summary = _adjust_author_summary(author_summary)
@@ -128,6 +129,7 @@ def _get_pr_summary(pr, author_summary):
 
     return pr_summary
 
+
 def _get_status_line(pr):
     """Get the line that shows the status of the PR.
 
@@ -137,11 +139,10 @@ def _get_status_line(pr):
     """
     if not cli_config.back:
         return f"\n{pr.url}\n\n"
-    
+
     if pr.merged:
         status = f"{flags.merged_flag} Merged."
     else:
         status = f"{flags.red_flag} Closed."
 
     return f"\n{status} {pr.url}\n\n"
-    

--- a/src/gh_profiler/utils/repo_data.py
+++ b/src/gh_profiler/utils/repo_data.py
@@ -1,7 +1,7 @@
 """One place to store all data about the targeted repo."""
 
 from dataclasses import dataclass
-from datetime import datetime as dt, timezone
+from datetime import datetime as dt
 
 
 @dataclass(slots=True)
@@ -21,10 +21,9 @@ class PRData:
     author: str = ""
     title: str = ""
     url: str = ""
-    
+
     merged: bool | None = None
     closed_at: dt | None = None
-
 
     # Processed info
     author_summary: str = ""

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -3,16 +3,17 @@
 import json
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC
+from datetime import datetime as dt
 from textwrap import dedent
 from time import perf_counter
-from datetime import datetime as dt, timezone
-
-from . import infra_utils
-from .profile_data import profile_data as pdata
-from .repo_data import repo_data, PRData
-from .cli_config import cli_config
 
 import httpx2
+
+from . import infra_utils
+from .cli_config import cli_config
+from .profile_data import profile_data as pdata
+from .repo_data import PRData, repo_data
 
 
 def get_data():
@@ -58,6 +59,7 @@ def _fetch_reachable():
     r = httpx2.get(cli_config.url)
     return r.status_code
 
+
 def _parse_reachable(reachable_str):
     """Parse output of reachable call."""
     if reachable_str == 200:
@@ -66,6 +68,7 @@ def _parse_reachable(reachable_str):
     msg = f"URL returned status code {reachable_str}."
     msg += "\n  Is the URL correct?"
     sys.exit(msg)
+
 
 def _fetch_prs():
     """Fetch relevant PRs.
@@ -98,14 +101,14 @@ def _parse_prs(prs_obj):
             _add_pr_back_fields(pr_dict, pr_data)
         target_prs.append(pr_data)
 
-    # When looking back, we grabbed more PRs than we need. Sort them by 
+    # When looking back, we grabbed more PRs than we need. Sort them by
     # closedAt, and return the number that were actually requested.
     if cli_config.back:
         target_prs.sort(key=lambda pr: pr.closed_at, reverse=True)
         target_prs = target_prs[:cli_config.num_targets]
 
-
     return target_prs
+
 
 def _get_author(pr_dict):
     """Get the author of the PR.
@@ -114,9 +117,8 @@ def _get_author(pr_dict):
     """
     if pr_dict["author"] is None:
         return "ghost"
-    else:
-        return pr_dict["author"]["login"]
-    
+    return pr_dict["author"]["login"]
+
 
 def _add_pr_back_fields(pr_dict, pr_data):
     """Add fields to PRData object that only related to looking back."""
@@ -131,8 +133,9 @@ def _add_pr_back_fields(pr_dict, pr_data):
 def _parse_gh_timestamp(ts):
     """Parse a gh API timestamp."""
     return dt.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
-        tzinfo=timezone.utc
+        tzinfo=UTC
     )
+
 
 def _get_pr_query():
     """Return the gh call for recent PRs in a repo."""
@@ -152,7 +155,6 @@ def _get_pr_query():
     else:
         # When looking at open PRs, no need to modify count.
         num_prs = cli_config.num_targets
-
 
     gh_call = f"""
         gh api graphql -f query='

--- a/src/gh_profiler/utils/repo_summary.py
+++ b/src/gh_profiler/utils/repo_summary.py
@@ -1,8 +1,6 @@
 """Utils for summarizing bulk PRs."""
 
 
-
-
 def show_summary(target_prs):
     """Show summary for all processed PRs."""
     for pr in target_prs:

--- a/src/gh_profiler/utils/summary_utils.py
+++ b/src/gh_profiler/utils/summary_utils.py
@@ -1,8 +1,9 @@
 """Utils for summarizing findings."""
 
 import humanize
-from .profile_data import profile_data as pdata
+
 from . import flags
+from .profile_data import profile_data as pdata
 
 
 def show_summary():
@@ -18,15 +19,14 @@ def _get_summary():
     """Build a summary string."""
     if pdata.username == "ghost":
         # This is GitHub's deleted user, and we don't need to do anything.
-        return f"🔴 The `ghost` account is GitHub's reference to a deleted user."
+        return "🔴 The `ghost` account is GitHub's reference to a deleted user."
 
     if pdata.redact:
         _redact_info()
 
     if pdata.concise:
         return _get_concise_summary()
-    else:
-        return _get_full_summary()
+    return _get_full_summary()
 
 
 def _get_concise_summary():
@@ -36,11 +36,11 @@ def _get_concise_summary():
     """
     if pdata.username == "ghost":
         # This is GitHub's deleted user, and we don't need to do anything.
-        return f"🔴 The `ghost` account is GitHub's reference to a deleted user."
-        
+        return "🔴 The `ghost` account is GitHub's reference to a deleted user."
+
     if pdata.redact:
         _redact_info()
-    
+
     summary = ""
     summary += f"GitHub user: {pdata.username}\n"
     summary += _get_profile_header()
@@ -70,9 +70,9 @@ def _get_section_header(flag, section):
     """Return a single line header for each main section of the summary."""
     if flag == flags.green_flag:
         return f"{flag} No concerns found with {section}.\n"
-    elif flag == flags.yellow_flag:
+    if flag == flags.yellow_flag:
         return f"{flag} Some concerns found with {section}.\n"
-    elif flag == flags.red_flag:
+    if flag == flags.red_flag:
         return f"{flag} Significant concerns found with {section}.\n"
 
 
@@ -127,7 +127,7 @@ def _redact_info():
 
     for social in pdata.socials:
         social["url"] = "<redacted>"
-    
+
     pdata.orgs = ["<redacted>"]
 
 
@@ -183,6 +183,7 @@ def _profile_summary():
 
     return summary
 
+
 def _bio_summary(bio):
     """Summarize bio section of profile."""
     if bio.count("\n") == 0:
@@ -199,7 +200,7 @@ def _org_summary():
     """Summarize user's orgs."""
     if not pdata.orgs:
         return ""
-    
+
     orgs_list = ", ".join(pdata.orgs)
     return f"      Orgs: {orgs_list}\n"
 

--- a/src/gh_profiler/utils/workflow_utils.py
+++ b/src/gh_profiler/utils/workflow_utils.py
@@ -1,8 +1,8 @@
 """Utils for writing a profile_contributors workflow to the user's repo."""
 
-from pathlib import Path
-import sys
 import importlib.resources
+import sys
+from pathlib import Path
 
 import click
 
@@ -22,6 +22,7 @@ def generate_workflow():
     # Write the workflow, and show a concluding message.
     _write_workflow(path, workflow_choice)
     _show_closing_message(path)
+
 
 def _get_workflow_choice():
     """Prompt the user for the kind of workflow they'd like to generate.
@@ -45,8 +46,8 @@ def _get_workflow_choice():
 
     if response == "1":
         return "concise_profile"
-    else:
-        return "link_only"
+    return "link_only"
+
 
 def _get_workflow_path():
     """Determine the path we'd like to write the workflow to."""
@@ -91,6 +92,7 @@ def _get_workflow_path():
     # No conflicts found. Note that .github/workflows/ may not exist.
     return path_pc_workflow
 
+
 def _confirm_write_workflow(path_workflow, workflow_choice):
     """Confirm the user wants the file written to the calculated location."""
     if workflow_choice == "concise_profile":
@@ -113,8 +115,9 @@ def _confirm_write_workflow(path_workflow, workflow_choice):
         confirmed = input(msg)
         if confirmed.lower() in ("y", "yes"):
             return
-        elif confirmed.lower() in ("n", "no"):
+        if confirmed.lower() in ("n", "no"):
             sys.exit()
+
 
 def _write_workflow(path_workflow, workflow_choice):
     """Write the workflow file to the correct location."""
@@ -135,6 +138,7 @@ def _write_workflow(path_workflow, workflow_choice):
 
     # Write profile_contributors.yml file.
     path_workflow.write_text(contents)
+
 
 def _show_closing_message(path):
     """Workflow was written, describe next steps."""

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -5,15 +5,15 @@ Makes an actual gh-profiler call. Currently calls against my own user account
 to use.
 """
 
-import subprocess
 import re
+import subprocess
 
 import pytest
 
 from gh_profiler.utils import infra_utils
 
-
 # --- Helper functions ---
+
 
 def run_with_timeout(cmd):
     """Run gh-profiler command, with a timeout."""
@@ -29,11 +29,10 @@ def run_with_timeout(cmd):
             # Did not time out, but check that we got a response.
             if output:
                 return output
-            else:
-                print("Got an empty response.")
-                num_attempts += 1
-                continue
-    
+            print("Got an empty response.")
+            num_attempts += 1
+            continue
+
     # Skip this entire module if there are too many timeouts.
     msg = "Too many timeouts."
     pytest.skip(msg, allow_module_level=True)
@@ -82,6 +81,7 @@ def test_full_run(target):
     for expected_string in expected_strings:
         assert expected_string in output
 
+
 def test_concise_run():
     """Test a --concise run of gh-profiler."""
     cmd = "uv run gh-profiler ehmatthes --concise"
@@ -103,6 +103,7 @@ def test_concise_run():
 
     for expected_string in expected_strings:
         assert expected_string in output
+
 
 def test_redact():
     """Test a --redact run of gh-profiler."""
@@ -129,6 +130,7 @@ def test_redact():
 
     # Should currently see 7 redacted fields in my output.
     assert output.count("<redacted>") == 7
+
 
 def test_bulk_open_prs():
     """Test a run against a repo URL for bulk processing open PRs."""
@@ -216,4 +218,4 @@ def test_ghost_profile(mode):
     cmd = f"uv run gh-profiler ghost {mode}"
     output = run_with_timeout(cmd)
 
-    assert output.strip() == f"🔴 The `ghost` account is GitHub's reference to a deleted user."
+    assert output.strip() == "🔴 The `ghost` account is GitHub's reference to a deleted user."

--- a/tests/integration_tests/test_workflows.py
+++ b/tests/integration_tests/test_workflows.py
@@ -1,14 +1,14 @@
 """Test the workflows that gh-profiler generates."""
 
+import shlex
 import subprocess
 from pathlib import Path
-import shlex
 
 import pytest
 
-
 path_templates = Path(__file__).parents[2] / "src" / "gh_profiler" / "templates"
-        
+
+
 @pytest.mark.parametrize(
     "path_workflow",
     [

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -4,8 +4,8 @@ from datetime import timedelta
 
 import pytest
 
-from gh_profiler.utils.profile_data import profile_data as pdata
 from gh_profiler.utils import flags
+from gh_profiler.utils.profile_data import profile_data as pdata
 
 
 @pytest.fixture(autouse=True)
@@ -64,7 +64,7 @@ def filled_pdata():
     pdata.flag_overall_issues = flags.green_flag
 
 
-@pytest.fixture()
+@pytest.fixture
 def empty_profile_info():
     """Empty the profile dict.
 

--- a/tests/unit_tests/test_adjust_flags.py
+++ b/tests/unit_tests/test_adjust_flags.py
@@ -1,9 +1,7 @@
 """Tests for making final adjustments to flags."""
 
+from gh_profiler.utils import analysis_utils, flags
 from gh_profiler.utils.profile_data import profile_data as pdata
-from gh_profiler.utils import analysis_utils
-from gh_profiler.utils import flags
-
 
 
 def test_account_age_all_green():
@@ -12,6 +10,7 @@ def test_account_age_all_green():
 
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
+
 
 def test_account_age_yellow():
     """Yellow age flag turns green when all others green."""
@@ -23,6 +22,7 @@ def test_account_age_yellow():
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
 
+
 def test_account_age_red():
     """Red age flag turns green when all others green."""
     pdata.flag_age = flags.red_flag
@@ -32,6 +32,7 @@ def test_account_age_red():
 
     assert pdata.flag_age == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
+
 
 def test_issues_flag_yellow():
     """Yellow age flag stays yellow when issues flag not green."""
@@ -44,6 +45,7 @@ def test_issues_flag_yellow():
     assert pdata.flag_age == flags.yellow_flag
     assert pdata.flag_overall_profile == flags.yellow_flag
 
+
 def test_no_pr_issue_activity():
     """If a user has not opened any recent PRs or issues, profile is green."""
     pdata.flag_profile = flags.yellow_flag
@@ -55,4 +57,3 @@ def test_no_pr_issue_activity():
 
     assert pdata.flag_profile == flags.green_flag
     assert pdata.flag_overall_profile == flags.green_flag
-    

--- a/tests/unit_tests/test_flag_evaluations.py
+++ b/tests/unit_tests/test_flag_evaluations.py
@@ -1,10 +1,7 @@
 """Tests for whether the correct flags are assigned, based on what's found."""
 
-from gh_profiler.utils import analysis_utils
-from gh_profiler.utils import summary_utils
+from gh_profiler.utils import analysis_utils, flags, summary_utils
 from gh_profiler.utils.profile_data import profile_data as pdata
-from gh_profiler.utils import flags
-
 
 
 def test_low_pr_volume_one_external_pr_closed():

--- a/tests/unit_tests/test_summary.py
+++ b/tests/unit_tests/test_summary.py
@@ -1,8 +1,9 @@
 """Tests for the summary that's generated."""
 
+from reference_files import reference_summaries
+
 from gh_profiler.utils import summary_utils
 from gh_profiler.utils.profile_data import profile_data as pdata
-from reference_files import reference_summaries
 
 
 def test_summary():
@@ -33,6 +34,7 @@ def test_no_issue_activity():
     assert "issues closed as NOT_PLANNED." not in summary
     assert "issues opened with the same title:" not in summary
 
+
 def test_summary_orgs():
     """Test that a user's orgs shows up in the summary."""
     pdata.orgs = ["org_1", "org_2", "org_3"]
@@ -49,6 +51,7 @@ def test_redact():
     assert "ehmatthes" not in summary
     assert summary.count("<redacted") == 6
 
+
 def test_full_concise_header_lines():
     """The full summary should include the same header lines as concise."""
     summary_full = summary_utils._get_summary()
@@ -61,6 +64,7 @@ def test_full_concise_header_lines():
     assert "No concerns found with user's profile." in summary_concise
     assert "No concerns found with recent PR activity." in summary_concise
     assert "No concerns found with recent issue activity." in summary_concise
+
 
 def test_concise():
     """Test output with pdata.concise set to True."""


### PR DESCRIPTION
Readability and style fixes across gh-profiler core modules from ShipGate auto-fix on source dirs.

## Summary

ShipGate reported **~83 format/style findings**, **~400 lint findings** in the full check suite. Security, duplication, and maintainability dimensions are summarized below; see the linked gist for raw captures.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.
### File hotspots

| File | Issues | Action |
| --- | ---: | --- |
| `src/gh_profiler/utils/profile_utils.py` | ~47 lint | address private-function; address E302 |
| `src/gh_profiler/utils/summary_utils.py` | ~41 lint | address private-function; wrap long lines or align with project line-length (E501) |
| `src/gh_profiler/utils/analysis_utils.py` | ~39 lint | address private-function; address E302 |
| `src/gh_profiler/utils/repo_fetching.py` | ~32 lint | address private-function; address W293 |
| `src/gh_profiler/utils/workflow_utils.py` | ~24 lint | wrap long lines or align with project line-length (E501); address E302 |
| `src/gh_profiler/cli.py` | ~22 lint | wrap long lines or align with project line-length (E501); address ARG001 |
| `src/gh_profiler/utils/repo_analysis.py` | ~21 lint | address W293; address private-function |
| `developer_resources/test_actual_users.py` | ~19 lint | address W293; address S101 |
| `tests/e2e_tests/test_profiler.py` | ~13 lint | wrap long lines or align with project line-length (E501); address E302 |
## What you are doing right

- **Dependencies:** pip-audit and deptry reported no critical vulnerabilities or unused dependency issues.
- **Dead code:** vulture/deadcode found few or no unused symbols in production modules.
- **Refactoring:** Strict refactor scan found only ~0 opportunities — structure is relatively stable.

## What you could improve

- **Duplication (~12.7%):** jscpd reports duplicate blocks above the configured threshold — review clustered paths in hotspots.
- **Complexity:** radon flagged functions or modules above cyclomatic-complexity gates — consider incremental extraction.
- **Lint / style (~400 findings):** Many items are formatting or style rules — align fixes with your existing ruff/pyproject config.
- **Hotspot:** `LICENSE.md` concentrates the most findings — start there for incremental cleanup.

## Changes

| Pass | Files | Fixes / rules | Manual? |
| --- | ---: | --- | --- |
| `shipgate format` | 0 | timeout or non-zero exit | no |
| `tests` | 0 | FAILED: python -m pytest -q | yes |
| **Total** | **0** | *See autofix.log for details* | — |
