### PR TITLE
Fix Windows encoding bugs, clean up dead code, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ This is a list of talks and discussions related to gh-profiler.
 Maintaining
 ---
 
+For a detailed look at the codebase, the data model, flag logic, Windows
+specifics, and the full test suite, see [documentation.md](documentation.md).
+
 ### `--redact`
 
 For live demos and screenshots, you can pass the `--redact` flag. The username and profile information sections will show "\<redacted\>" in place of identifying information:

--- a/developer_resources/test_actual_users.py
+++ b/developer_resources/test_actual_users.py
@@ -69,7 +69,7 @@ def run_with_timeout(cmd):
     num_attempts = 0
     while num_attempts < 5:
         try:
-            result = infra_utils.run_cmd(cmd, timeout=5)
+            result = infra_utils.run_cmd(cmd, timeout=20)
             output = result.stdout
         except subprocess.TimeoutExpired:
             print("Time out.")

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,492 @@
+# gh-profiler: Developer Documentation
+
+Detailed documentation for working on gh-profiler. This covers the architecture,
+the data model, the flag logic, the known issues that have been fixed, Windows
+specifics, and how to set up and run every part of the test suite.
+
+For general usage of the tool, see the README.
+
+---
+
+## 1. What the tool does
+
+gh-profiler is a Python CLI that examines a GitHub user's profile and recent
+activity, so a maintainer can decide how much effort to invest in reviewing a
+new PR or issue. It reports three color flags per area:
+
+| Flag | Meaning |
+|---|---|
+| Green (🟢) | No concerns found |
+| Yellow (🟡) | Some concerns found |
+| Red (🔴) | Significant concerns found |
+
+It evaluates three areas:
+
+1. **Profile**: account age, how much profile info is filled in, social accounts.
+2. **PR activity**: PRs opened against repos the user owns, repos in public
+   orgs, and external repos over the last 21 days. Only *external* PRs feed the
+   flags, and only merged vs. closed-without-merging ratios matter.
+3. **Issue activity**: issues closed as NOT_PLANNED, and identical issue titles
+   opened across multiple repos over the last 21 days (spam signal).
+
+The tool is deliberately not meant to be a hard decision engine. It surfaces
+evidence and leaves the decision to the maintainer.
+
+## 2. How it talks to GitHub
+
+gh-profiler does **not** use the GitHub REST API directly. It shells out to the
+GitHub CLI (`gh`) for everything:
+
+- `gh api users/<user>` for the profile.
+- `gh api users/<user>/orgs` and `gh api users/<user>/social_accounts`.
+- `gh api graphql ...` for recent PR and issue activity (search queries).
+- `gh api graphql ... repository(...)` for bulk PR processing of a repo.
+- `gh pr view` / `gh issue view` when the target is a PR or issue number.
+- `gh auth status` to confirm authentication.
+
+All shelling out goes through one function, `infra_utils.run_cmd()`, which
+runs a command via `subprocess` and returns a `CommandResult` with `stdout`,
+`stderr`, and `returncode`. Environment variables disable color output
+(`NO_COLOR=1`, `CLICOLOR_FORCE=0`) so gh's output is always machine-readable
+plain text.
+
+`gh` must be installed and authenticated. `git` alone is not enough; being able
+to push and pull does not mean `gh` is present.
+
+## 3. Project layout
+
+```
+src/gh_profiler/
+  cli.py                    # Click entry point; argument parsing, target dispatch
+  gh_profiler.py            # high-level main() / profile_url() orchestration
+  __main__.py               # enables python -m gh_profiler
+  __init__.py               # package marker
+  templates/                # GitHub Actions workflow templates (2 files)
+  utils/
+    profile_data.py         # ProfileData dataclass + singleton pdata
+    repo_data.py            # RepoData / PRData dataclasses + repo_data singleton
+    cli_config.py           # CLIConfig singleton cli_config (CLI options)
+    flags.py                # emoji flag constants
+    infra_utils.py          # run_cmd() subprocess wrapper, CommandResult
+    profile_utils.py        # fetch + parse user profile and activity data
+    analysis_utils.py       # evaluate flags from parsed data
+    summary_utils.py        # render full / concise summary text
+    cli_utils.py            # PR/issue-number target handling
+    repo_fetching.py        # bulk fetch of a repo's PRs
+    repo_analysis.py        # bulk profiling + Rich summary table
+    workflow_utils.py       # write profile_contributors.yml
+tests/
+  unit_tests/               # fast tests with no network access
+  integration_tests/        # zizmor security checks on generated workflows
+  e2e_tests/                # live tests against real GitHub (network + gh)
+developer_resources/        # benchmark script + manual actual-user tests
+.github/workflows/          # test.yml + this repo's profiling workflow
+```
+
+## 4. Data model
+
+### Singleton objects
+
+The codebase uses three module-level singletons. This is a known design
+decision (see "Known limitations").
+
+- `ProfileData` (`profile_data.py`) holds everything learned about the target
+  user: profile fields, orgs, social accounts, PR/issue counts, and all flags.
+  It is `slots=True` so the field list is locked down. `reset_fields()` exists
+  only to reuse the singleton per-PR during bulk processing; it is expected to
+  disappear when `pdata` stops being a singleton.
+- `RepoData` (`repo_data.py`) holds the owner and repo name when targeting a
+  repo URL. `PRData` holds one PR's raw and processed info (number, author,
+  title, url, merged state, plus the computed flags and summaries for bulk
+  output).
+- `CLIConfig` (`cli_config.py`) holds the CLI options that bulk processing
+  needs (num targets, --back, redact, table-only).
+
+### CommandResult
+
+`infra_utils.CommandResult` is a simple dataclass with `stdout`, `stderr`, and
+`returncode`. Callers should check `returncode`; the fetch layer does.
+
+## 5. Fetch, parse, analyze, summarize
+
+The pipeline is deliberately split into stages. Fetching is the only slow part
+and is the only part that runs concurrently.
+
+```
+cli.py               parse args, decide target type
+gh_profiler.py       orchestrate
+profile_utils        fetch (thread pool) -> parse into pdata
+analysis_utils       evaluate flags from pdata
+summary_utils        render summary string
+```
+
+### Single-user flow (`gh-profiler <username>`)
+
+1. `cli.main()` validates args and stores behavior flags on `pdata` (concise,
+   verbose, redact, benchmark, generate-workflow).
+2. `gh_profiler.main()` calls `profile_utils.ensure_gh()`, then
+   `profile_utils.get_data()`.
+3. `get_data()` submits six fetch calls to a `ThreadPoolExecutor`. The status
+   call resolves first and is checked for authentication, then the remaining
+   results are collected with per-call error guarding.
+4. Parse functions fill `pdata`.
+5. `analysis_utils.process_data()` computes flags, then a final
+   `_adjust_flags()` pass applies false-positive guards.
+6. `summary_utils.show_summary()` builds and prints the summary.
+
+### Bulk flow (`gh-profiler <repo-url>`)
+
+1. `repo_fetching.get_data()` queries the repo for its n most recent open PRs
+   (or, with `--back`, closed/merged PRs).
+2. `repo_analysis.process_data()` profiles each PR author, reusing profiles for
+   repeat authors via `_get_cached_author_info()`.
+3. Results print inline and as a rich table. With `--back`, a Merged? column is
+   added.
+
+## 6. Flag evaluation logic
+
+### Account age (`analysis_utils._process_account_age`)
+
+| Age | Flag |
+|---|---|
+| older than 3 years | Green |
+| 90 days to 3 years | Yellow |
+| younger than 90 days | Red |
+
+`created_at` is parsed with `datetime.fromisoformat`, with a manual fallback
+for Python 3.10's stricter handling.
+
+### Profile info (`_process_profile_info`)
+
+Counts filled fields among name, company, blog, location, email, bio, plus
+social account URLs.
+
+| Filled count | Flag |
+|---|---|
+| 0 | Red |
+| 1-2 | Yellow |
+| 3+ | Green |
+
+### PR activity (`_process_pr_activity`)
+
+Only PRs against *external* repos are analyzed. Below 4 external PRs, both PR
+flags are set green (low volume should never trip flags). Otherwise:
+
+- `ratio_closed > 0.5` -> Red flag for closed PRs. `flag_merged_pr` is None
+  unless the merge ratio is healthy (never yellow or red for merged).
+- The merged flag only ever shows green (PRs sitting open awaiting merge is
+  normal, so a low merge ratio is not penalized).
+
+### Issue activity (`_process_issue_activity`)
+
+Only external issues are analyzed.
+
+- NOT_PLANNED count: 0-3 green, 4-5 yellow, 6+ red.
+- Repeated identical titles: 0-3 green, 4-5 yellow, 6+ red. Identical titles
+  can be legitimate (opening on the wrong repo then the right one), which is
+  why the green band is generous.
+
+### Overall flags (`_set_overall_flags`)
+
+An overall section flag is red if any component is red, else yellow if any is
+yellow, else green.
+
+### False-positive guard pass (`_adjust_flags`)
+
+- `_adjust_account_age_flag`: if the account age flag is not green but
+  everything else is green, the age flag is set green. This stops a brand new
+  account from looking bad when the user has no other concerning activity.
+- `_adjust_profile_flag_no_pr_issue_activity`: if the user has opened no recent
+  PRs or issues, profile and overall-profile flags are set green. This covers
+  people who scrubbed their profile but have not deleted their account.
+
+## 7. Target types
+
+`cli.py` routes a target to one of four paths:
+
+| Target | Behavior |
+|---|---|
+| Bare username (`ehmatthes`) | Single-user profile |
+| Profile URL (`https://github.com/ehmatthes`) | Same as username (`_parse_profile_url` detects owner-only URL) |
+| Repo URL (`https://github.com/org/repo`) | Bulk processing of recent PRs |
+| Integer (`8`) | Look up PR or issue in the current/default repo via `gh repo view` |
+
+A repo URL is detected after the profile-URL check fails. Any target containing
+`github.com` that is not a profile URL is treated as a repo URL.
+
+The `ghost` user gets a special case everywhere: it is GitHub's stand-in for a
+deleted account, and produces a single red line instead of a normal profile.
+
+## 8. CLI options
+
+| Option | Purpose |
+|---|---|
+| `-n / --num-targets` | How many PRs to review in bulk mode. Validated to 1..100. |
+| `--back` | Look at recently closed/merged PRs instead of open ones. |
+| `--table-only` | Bulk mode: only print the final summary table. |
+| `--generate-workflow` | Write a `.github/workflows/profile_contributors.yml`. |
+| `-v / --verbose` | Print rationale for flag adjustments. |
+| `--redact` | Hide identifying info (for demos/screenshots). |
+| `--concise` | One line per section instead of the full report. |
+| `--benchmark-fetch` | Time just the network fetching block. |
+| `-h / --help`, `--version` | Help and version. |
+
+No `--issues` option exists in code; it was removed as dead wiring.
+
+## 9. Workflow generation
+
+`workflow_utils.generate_workflow()` writes a GitHub Actions workflow that runs
+`gh-profiler --concise` on every new PR and issue author.
+
+- The user picks whether the concise profile is posted as a comment, or only a
+  link to the Actions log is posted.
+- The workflow also cleans up: when the issue or PR closes, the profile comment
+  and the linked Actions logs are deleted.
+- The templates live in `src/gh_profiler/templates/` and are security-checked by
+  the zizmor integration test.
+- If `.git` is missing, the tool refuses to write a workflow.
+- If the workflow file already exists, the user is asked whether to replace it.
+
+## 10. Issues found and fixed
+
+This section records concrete problems fixed while working on the codebase.
+
+### 10.1 `path_cwd` NameError in workflow generation
+
+`workflow_utils._get_workflow_path()` referenced an undefined `path_cwd`. When
+`.git` was missing, the intended friendly message was replaced by a
+`NameError`. Fixed to use `Path.cwd().as_posix()`.
+
+### 10.2 `_get_repo_slug` whitespace handling
+
+`cli_utils._get_repo_slug()` stripped its output into a local variable, but
+checked and returned the unstripped `result.stdout`. Trailing whitespace leaked
+into repo slugs, and a whitespace-only reply bypassed the guard. Now the
+stripped value is the only one used.
+
+### 10.3 Case-sensitive repo classification drift
+
+Owned-repo matching used `casefold()` for PRs but plain `==` for issues.
+GitHub logins are case-insensitive, so a same-user repo could be miscounted as
+"external" for issue activity. Both parsers now share one helper,
+`_classify_repos()`, which casefolds logins and org names everywhere.
+
+### 10.4 Unreachable branch in `_process_pr_activity`
+
+After the `< 4 external PRs` early return, a second `opened_count_external == 0`
+check was unreachable and misleading. Removed.
+
+### 10.5 `issueCount` vs. analyzed nodes
+
+The issue search caps results at 100 nodes, but `issueCount` can report a
+larger number. The count now reflects what was actually analyzed
+(`len(nodes)`), so reported numbers always agree with the analysis. Page
+graph access remains as a known limitation; real pagination is future work.
+
+### 10.6 Fetch failures misreported as timeouts
+
+Every parser blamed timeouts (`Couldn't get ... may have timed out`) whenever
+parsing failed, hiding real errors such as 404s, rate limits, and bad tokens.
+The fetch layer now checks `returncode` and surfaces gh's `stderr` via
+`profile_utils._run_gh_cmd()`. A 404 on the profile call produces a clear
+"GitHub user '<name>' not found."
+
+### 10.7 Opaque thread pool failures
+
+A single failing fetch used to crash the whole run with a raw traceback.
+`get_data()` now resolves the auth status first, then collects each remaining
+result with per-call error guarding, exiting with an explanatory message.
+
+### 10.8 Dead reachability code and dead dependency
+
+`repo_fetching._fetch_reachable()` / `_parse_reachable()` were commented out of
+the flow, and the only consumer of the `httpx2` dependency was that dead code.
+Both the functions and the `httpx2` dependency (and its transitive packages)
+were removed. `uv lock` regenerates a clean lockfile.
+
+### 10.9 Unused `repo_summary.py` and leftover debug
+
+`repo_summary.show_summary()` was commented out at its only call site, so the
+module was dead. Deleted. Also removed a commented-out `# breakpoint()`.
+
+### 10.10 Half-wired CLI options
+
+`cli_config.url`, `cli_config.issues`, a `--issues` click option, and a
+commented assignment were leftovers. Nothing read them; removed.
+
+### 10.11 `httpx2` in dependency list
+
+See 10.8. pyproject.toml and uv.lock no longer contain `httpx2`.
+
+### 10.12 Encodings on Windows
+
+Two real Windows bugs:
+
+- `infra_utils.run_cmd()` decoded gh output as strict UTF-8. On Windows gh can
+  print text in the system codepage (e.g. cp1252), which is not valid UTF-8,
+  raising `UnicodeDecodeError`. The decoder now uses `errors="replace"`.
+- `rich` writes the emoji flags to stdout; on Windows stdout defaults to the
+  system codepage and cannot hold emoji, raising `UnicodeEncodeError` when
+  rendering the bulk table. The CLI now reconfigures stdout and stderr to
+  UTF-8 at startup (`cli._ensure_utf8_output()`).
+
+### 10.13 Validation of bulk count
+
+`-n / --num-targets` only guarded the upper bound. It now also rejects values
+below 1.
+
+## 11. Windows notes
+
+- `gh` output may not be UTF-8; the fetch layer tolerates that (10.12).
+- Emoji output requires UTF-8 stdout; the CLI forces it (10.12).
+- `infra_utils.run_cmd()` uses `shlex.split`; Windows paths with backslashes in
+  commands can therefore be mangled, so tests avoid such paths (they substitute
+  forward slashes).
+- Tests that shell out (`tests/e2e_tests`, `developer_resources`) run gh through
+  `uv run gh-profiler`. The `uv` executable and the `gh` executable must be on
+  PATH for the spawned subprocesses.
+- The e2e helper guards each run with a 20 second timeout and retries. On a
+  busy machine, a run can still time out and the test will skip; see
+  `run_with_timeout` in each file.
+
+## 12. Development environment
+
+Requirements:
+
+- Python 3.10 or newer (`.python-version` pins 3.14 for local tooling).
+- `uv` (the project uses uv for sync, lock, and running).
+- The GitHub CLI `gh`, installed and authenticated (`gh auth login`).
+
+Set up the environment:
+
+```sh
+uv sync
+```
+
+This creates `.venv` and installs the runtime and dev dependencies
+(pytest, pytest-xdist, zizmor). If a fresh shell does not find `uv` or `gh`,
+prepend their install directories to PATH (they get installed to Python's
+Scripts dir and to the GitHub CLI install dir respectively).
+
+Verify the environment:
+
+```sh
+uv run gh --version    # gh CLI
+uv run python --version
+gh auth status         # logged in? which token scopes?
+```
+
+## 13. Running tests
+
+### Unit tests
+
+```sh
+uv run pytest tests/unit_tests
+```
+
+Fast, no network, no gh. Cover flag evaluation, summary rendering, argument
+parsing, fetching/parsing helpers, repo parsing, workflow path handling, and
+the subprocess wrapper.
+
+### Integration tests
+
+```sh
+uv run pytest tests/integration_tests
+```
+
+Requires `zizmor` (a dev dependency). Runs the security checker against the
+generated workflow templates. Both templates must report no findings.
+
+### End-to-end tests
+
+```sh
+uv run pytest tests/e2e_tests
+```
+
+Requires `gh` (installed and authenticated) and network access. These make
+real API calls and can be flaky by nature. They are not collected by default
+(`conftest.py` uses `collect_ignore`). Tests:
+
+- Full, concise, and redacted runs against the author's account.
+- Bulk runs against https://github.com/django/django (open and --back).
+- The `ghost` account special case.
+- PR/issue number targets, via the default repo. The targets (#1, #3) exist in
+  the upstream `ehmatthes/gh-profiler` repo, so the default repo must resolve
+  there (`gh repo set-default ehmatthes/gh-profiler`). A fork without those
+  PRs/issues will skip those tests.
+
+### Live user checks and benchmark
+
+```sh
+uv run pytest developer_resources/test_actual_users.py -s
+```
+
+Runs against a set of known-green and known-problematic real users. Usernames
+must be stored in a private `actual_users.toml` that lives outside the repo (the
+test looks for it via the `PATH_ACTUAL_USERS` env var or
+`<repo-parent>/gh-profiler_support/actual_users.toml`). A version with real
+names must never be committed.
+
+```sh
+uv run developer_resources/benchmark.py
+```
+
+Times several runs against a target to watch for performance regressions.
+
+### All local tests
+
+```sh
+./test_all.sh
+```
+
+Shell script that runs unit, e2e, and live-user tests. Works on macOS and
+probably Linux; may not work on Windows.
+
+Running only the collectible suites on any platform (recommended default):
+
+```sh
+uv run pytest
+```
+
+## 14. Known limitations
+
+- **pdata is a global singleton.** Reused and reset per PR during bulk
+  processing via `reset_fields()`. This blocks threading bulk profiling; the
+  commented-out parallel path in `repo_analysis` needs a non-singleton data
+  object. Until then, state must not leak across tests (fixtures reset it).
+- **No pagination on activity fetches.** PR/issue activity is capped at 100
+  nodes from the search API. Counts now reflect the analyzed nodes, but a very
+  active user could have more activity than is inspected.
+- **`--back` set differs from GitHub's UI.** The back-mode query fetches
+  closed/merged PRs ordered by `UPDATED_AT` then re-sorts by `closedAt`, so the
+  set of PRs shown may not match the repo's "closed" tab (documented in the
+  README note).
+- **e2e and live-user tests are inherently flaky.** They depend on network
+  latency, gh rate limits, and live GitHub data.
+- **Windows output depends on UTF-8.** The CLI forces UTF-8 stdout/stderr; on
+  legacy consoles the emoji may not render even though output is well-formed.
+
+## 15. Release process
+
+Per README:
+
+1. Update CHANGELOG and bump the version in pyproject.toml.
+2. `uv lock`.
+3. Commit all changes.
+4. `git tag vX.Y.Z`.
+5. `git push origin vX.Y.Z`.
+6. `rm -rf dist/*`, `uv build`, `uv publish`.
+
+## 16. Code conventions
+
+- Keep fetch -> parse -> analyze -> present separation.
+- Fetching is the only part that should touch the network, and the only part
+  that runs in parallel.
+- Terse output lines over verbose ones (e.g. "0 issues closed as NOT_PLANNED."
+  not "0 issues have been closed as NOT_PLANNED.").
+- As evaluation rules get complicated, keep the false-positive guard pass
+  separate from the individual-flag logic so rules can be reasoned about and
+  unit tested in isolation.
+- Add a unit test for any new parsing or flagging logic; the modules most prone
+  to regressions (profile_utils, repo_fetching, workflow_utils, cli_utils,
+  infra_utils) all have dedicated test files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.3.3",
-    "httpx2>=2.3.0",
     "humanize>=4.15.0",
     "rich>=15.0.0",
 ]

--- a/src/gh_profiler/cli.py
+++ b/src/gh_profiler/cli.py
@@ -17,7 +17,6 @@ from .utils.cli_config import cli_config
 @click.version_option(package_name="gh-profiler")
 @click.option("--concise", is_flag=True, help="Show concise output; one flag per category.")
 @click.option("-n", "--num-targets", default=10, help="Preview: How many PRs to review?")
-# @click.option("--issues", is_flag=True, help="Profile contributors of issues rather than PRs.")
 @click.option("--back", is_flag=True, help="Look back over recently merged and closed PRs.")
 @click.option("--table-only", is_flag=True, help="For bulk processing, only show comparison table.")
 @click.option(
@@ -56,6 +55,8 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
     $ gh-profiler <repo-url> --back
     $ gh-profiler <repo-url> --back -n 20 --table-only
     """
+    _ensure_utf8_output()
+
     _validate_command(target, concise, num_targets, generate_workflow, verbose, redact, benchmark_fetch)
 
     # Parse CLI options.
@@ -79,7 +80,6 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
             pdata.username = username
             gh_profiler.main()
 
-        cli_config.url = target
         _parse_repo_options(num_targets, back, redact, table_only)
         _parse_repo_info(target)
         gh_profiler.profile_url()
@@ -97,6 +97,19 @@ def main(target, concise, num_targets, back, table_only, generate_workflow, verb
         cli_utils.process_pr_issue_num(pr_issue_num)
         gh_profiler.main()
 
+def _ensure_utf8_output():
+    """Make sure stdout and stderr can hold the emoji flags.
+
+    On Windows, output defaults to the system codepage (cp1252 here), which
+    has no room for emoji. That made rich crash with a UnicodeEncodeError
+    whenever a flag was printed. Forcing UTF-8 keeps that from happening,
+    whether the output goes to a terminal or is piped.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
+
 def _validate_command(target, concise, num_targets, generate_workflow, verbose, redact, benchmark_fetch):
     """Validate arguments that were passed in the CLI call."""
 
@@ -111,9 +124,13 @@ def _validate_command(target, concise, num_targets, generate_workflow, verbose, 
         msg = "Please either include a target or --generate-workflow, but not both."
         sys.exit(msg)
     
-    # For any bulk request, you can request up to 100 records.
+    # For any bulk request, you can request up to 100 records, but at least 1.
     if num_targets > 100:
         msg = "You can request up to 100 targets. (-n, --num-targets)"
+        sys.exit(msg)
+
+    if num_targets < 1:
+        msg = "You must request at least 1 target. (-n, --num-targets)"
         sys.exit(msg)
 
 
@@ -135,7 +152,6 @@ def _parse_profile_url(target):
 def _parse_repo_options(num_targets, back, redact, table_only):
     """Get options relevant to targeting a repo URL."""
     cli_config.num_targets = num_targets
-    # cli_config.issues = issues
     cli_config.back = back
     cli_config.redact = redact
     cli_config.table_only = table_only

--- a/src/gh_profiler/gh_profiler.py
+++ b/src/gh_profiler/gh_profiler.py
@@ -11,7 +11,7 @@ from .utils import profile_utils
 from .utils import analysis_utils
 from .utils import workflow_utils
 from .utils import summary_utils
-from .utils import repo_fetching, repo_analysis, repo_summary
+from .utils import repo_fetching, repo_analysis
 
 
 def main():
@@ -55,10 +55,6 @@ def profile_url():
     # Get and analyze all the data we'll need.
     target_prs = repo_fetching.get_data()
     repo_analysis.process_data(target_prs)
-
-    # DEV: This will be used when bulk processing of PRs is done in parallel.
-    # That requires pdata to not be a singleton.
-    # repo_summary.show_summary(target_prs)
 
     # Don't return to cli.
     sys.exit()

--- a/src/gh_profiler/utils/analysis_utils.py
+++ b/src/gh_profiler/utils/analysis_utils.py
@@ -90,12 +90,6 @@ def _process_pr_activity():
         return
 
     # All the following analysis focuses on PRs against external repos.
-    if pdata.opened_count_external == 0:
-        # DEV: Do these need to be set?
-        pdata.flag_merged_pr = flags.green_flag
-        pdata.flag_closed_pr = flags.green_flag
-        return
-
     ratio_merged = pdata.merged_count_external / pdata.opened_count_external
     ratio_closed = pdata.closed_count_external / pdata.opened_count_external
 

--- a/src/gh_profiler/utils/cli_config.py
+++ b/src/gh_profiler/utils/cli_config.py
@@ -8,11 +8,7 @@ class CLIConfig:
     """The main place to store options that are passed in the gh-profiler cmd.
     """
 
-    # If target is a URL, store that here.
-    url: str = ""
     num_targets: int | None = None
-
-    issues: bool | None = None
     back: bool | None = None
 
     redact: bool | None = None

--- a/src/gh_profiler/utils/cli_utils.py
+++ b/src/gh_profiler/utils/cli_utils.py
@@ -28,15 +28,15 @@ def process_pr_issue_num(pr_issue_num):
 def _get_repo_slug():
     """Ask `gh` for the resolved default repo (honors `gh repo set-default`)."""
     result = run_cmd("gh repo view --json nameWithOwner --jq .nameWithOwner")
-    output = result.stdout.strip()
-    
-    if not result.stdout:
+    repo_slug = result.stdout.strip()
+
+    if not repo_slug:
         msg = (
             "Couldn't determine the default GitHub repository. "
             "Run `gh repo set-default` in this directory and try again."
         )
         sys.exit(msg)
-    return result.stdout
+    return repo_slug
 
 
 def _process_pr(pr_issue_num, repo_slug):

--- a/src/gh_profiler/utils/infra_utils.py
+++ b/src/gh_profiler/utils/infra_utils.py
@@ -23,10 +23,17 @@ class CommandResult:
 def run_cmd(cmd, env=DEFAULT_ENV, timeout=None):
     """Run a subprocess command, return CommandResult instance."""
     cmd_parts = shlex.split(cmd)
-    output_obj = subprocess.run(cmd_parts, capture_output=True, env=env, timeout=timeout)
+    output_obj = subprocess.run(
+        cmd_parts,
+        capture_output=True,
+        env=env,
+        timeout=timeout,
+        encoding="utf-8",
+        errors="replace",
+    )
 
     return CommandResult(
-        stdout=output_obj.stdout.decode(),
-        stderr=output_obj.stderr.decode(),
+        stdout=output_obj.stdout,
+        stderr=output_obj.stderr,
         returncode=output_obj.returncode,
     )

--- a/src/gh_profiler/utils/profile_data.py
+++ b/src/gh_profiler/utils/profile_data.py
@@ -1,6 +1,7 @@
 """One place to store all data about the user."""
 
 from dataclasses import dataclass, fields, MISSING
+from datetime import timedelta
 
 
 @dataclass(slots=True)
@@ -31,7 +32,7 @@ class ProfileData:
     profile_dict: dict | None = None
     profile_info: dict | None = None
 
-    account_age: int = 0
+    account_age: timedelta = timedelta(0)
     orgs: list | None = None
     socials: list | None = None
 

--- a/src/gh_profiler/utils/profile_utils.py
+++ b/src/gh_profiler/utils/profile_utils.py
@@ -46,20 +46,30 @@ def get_data():
     ts_before = perf_counter()
     with ThreadPoolExecutor() as executor:
         # Make fetching calls.
-        status_future = executor.submit(_fetch_status)
-        profile_dict_future = executor.submit(_fetch_profile_dict)
-        orgs_future = executor.submit(_fetch_orgs)
-        socials_future = executor.submit(_fetch_socials)
-        pr_activity_future = executor.submit(_fetch_pr_activity)
-        issue_activity_future = executor.submit(_fetch_issue_activity)
+        fetch_calls = {
+            "status": executor.submit(_fetch_status),
+            "profile": executor.submit(_fetch_profile_dict),
+            "orgs": executor.submit(_fetch_orgs),
+            "socials": executor.submit(_fetch_socials),
+            "recent PR activity": executor.submit(_fetch_pr_activity),
+            "recent issue activity": executor.submit(_fetch_issue_activity),
+        }
 
-        # When each call finishes, store the result.
-        status_obj = status_future.result()
-        profile_dict_str = profile_dict_future.result()
-        orgs_str = orgs_future.result()
-        socials_str = socials_future.result()
-        pr_activity_str = pr_activity_future.result()
-        issue_activity_str = issue_activity_future.result()
+        # Auth is the one failure we want to explain ourselves, so resolve and
+        # check that call first.
+        status_obj = fetch_calls["status"].result()
+
+        # If a fetch fails, the gh call itself went wrong and the message says
+        # what happened. One bad call shouldn't take down the whole run with an
+        # opaque traceback, so guard each call as we collect results.
+        fetch_results = {}
+        for name, future in fetch_calls.items():
+            if name == "status":
+                continue
+            try:
+                fetch_results[name] = future.result()
+            except ValueError as e:
+                sys.exit(e)
 
     ts_after = perf_counter()
     if pdata.benchmark_fetch:
@@ -67,14 +77,33 @@ def get_data():
 
     # Parse data. This should only happen after all data has been fetched.
     _parse_status(status_obj)
-    _parse_profile_dict(profile_dict_str)
-    _parse_orgs(orgs_str)
-    _parse_socials(socials_str)
-    _parse_pr_activity(pr_activity_str)
-    _parse_issue_activity(issue_activity_str)
+    _parse_profile_dict(fetch_results["profile"])
+    _parse_orgs(fetch_results["orgs"])
+    _parse_socials(fetch_results["socials"])
+    _parse_pr_activity(fetch_results["recent PR activity"])
+    _parse_issue_activity(fetch_results["recent issue activity"])
 
 
 # --- Helper functions ---
+
+def _run_gh_cmd(cmd, context):
+    """Run a gh command and make sure it actually worked.
+
+    We used to parse whatever came back and blame timeouts whenever parsing
+    failed, which hid the real problem (bad token, 404, rate limit, and so on).
+    Checking the return code and reading stderr gives the user a much better
+    message. This raises ValueError, which callers can catch or let ride.
+    """
+    result = infra_utils.run_cmd(cmd)
+    if result.returncode != 0:
+        msg = f"Couldn't fetch {context} from GitHub."
+        if result.stderr:
+            msg += f"\n  gh said: {result.stderr.strip()}"
+        else:
+            msg += "\n  The gh CLI may have timed out."
+        msg += "\n  You may want to try running the command again."
+        raise ValueError(msg)
+    return result
 
 def _fetch_status():
     """Fetch output of `gh auth status`.
@@ -113,6 +142,20 @@ def _fetch_profile_dict():
     """Fetch the profile information we'll need."""
     cmd = f"gh api users/{pdata.username} --jq '{{login, name, created_at, company, blog, location, email, bio}}'"
     result = infra_utils.run_cmd(cmd)
+
+    # A nonexistent user comes back as a 404, so give that a clear message
+    # instead of a generic failure.
+    if result.returncode != 0:
+        if "404" in result.stderr:
+            sys.exit(f"GitHub user '{pdata.username}' not found.")
+        msg = f"Couldn't fetch profile info from GitHub."
+        if result.stderr:
+            msg += f"\n  gh said: {result.stderr.strip()}"
+        else:
+            msg += "\n  The gh CLI may have timed out."
+        msg += "\n  You may want to try running the command again."
+        raise ValueError(msg)
+
     return result.stdout
 
 def _parse_profile_dict(profile_dict_str):
@@ -142,7 +185,7 @@ def _fetch_orgs():
         f"gh api users/{pdata.username}/orgs "
         "--jq '[.[] | {login, description, url}]'"
     )
-    result = infra_utils.run_cmd(cmd)
+    result = _run_gh_cmd(cmd, "org info")
 
     return result.stdout
 
@@ -157,6 +200,36 @@ def _parse_orgs(orgs_str):
 
     pdata.orgs = [org["login"] for org in orgs]
 
+def _classify_repos(nodes, username, orgs):
+    """Split nodes into owned, org, and external repos.
+
+    GitHub logins are case-insensitive, so we compare casefolded values
+    everywhere. The original PR and issue parsers each did this by hand, and
+    they drifted apart (issues were case-sensitive, PRs were not). One helper
+    keeps them in sync.
+    """
+    username_casefold = username.casefold()
+    orgs_casefold = {org.casefold() for org in orgs}
+
+    owned = [
+        node for node in nodes
+        if node["repository"]["owner"]["login"].casefold() == username_casefold
+    ]
+
+    in_orgs = [
+        node for node in nodes
+        if node not in owned
+        and node["repository"]["owner"]["login"].casefold() in orgs_casefold
+    ]
+
+    external = [
+        node for node in nodes
+        if node not in owned
+        and node not in in_orgs
+    ]
+
+    return owned, in_orgs, external
+
 def _fetch_socials():
     """Fetch social media accounts from user's profile.
     
@@ -164,7 +237,7 @@ def _fetch_socials():
     they require an additional API call.
     """
     cmd = f"gh api users/{pdata.username}/social_accounts"
-    result = infra_utils.run_cmd(cmd)
+    result = _run_gh_cmd(cmd, "social account info")
 
     return result.stdout
 
@@ -187,7 +260,7 @@ def _fetch_pr_activity():
         f"author:{pdata.username} is:pull-request is:public created:>={cutoff}"
     )
     cmd = f"gh api graphql -f query='{pr_query}' -F q='{search_query}' -F n=100"
-    result = infra_utils.run_cmd(cmd)
+    result = _run_gh_cmd(cmd, "recent PR activity")
 
     return result.stdout
 
@@ -205,29 +278,10 @@ def _parse_pr_activity(pr_activity_str):
 
     pdata.opened_count = len(prs)
 
-    # PRs against repos the user owns.
-    prs_owned = [
-        pr for pr in prs
-        if pr["repository"]["owner"]["login"].casefold()
-        == pdata.username.casefold()
-    ]
+    prs_owned, prs_orgs, prs_external = _classify_repos(prs, pdata.username, pdata.orgs)
 
     pdata.opened_count_owned = len(prs_owned)
-
-    # PRS against repos in orgs the user is publicly associated with.
-    prs_orgs = [
-        pr for pr in prs
-        if pr["repository"]["owner"]["login"] in pdata.orgs
-    ]
-
     pdata.opened_count_orgs = len(prs_orgs)
-
-    # PRs against external repos.
-    prs_external = [
-        pr for pr in prs
-        if pr not in prs_owned
-        and pr not in prs_orgs
-    ]
     pdata.opened_count_external = len(prs_external)
     pdata.merged_count_external = sum(pr["mergedAt"] is not None for pr in prs_external)
     pdata.closed_count_external = sum(
@@ -238,7 +292,7 @@ def _fetch_issue_activity():
     """Fetch target user's recent public issue activity."""
     cutoff = (dt.now(tz.utc) - timedelta(days=21)).date().isoformat()
     gh_call = _get_gh_issues_call(pdata.username, cutoff)
-    result = infra_utils.run_cmd(gh_call)
+    result = _run_gh_cmd(gh_call, "recent issue activity")
 
     return result.stdout
 
@@ -252,23 +306,14 @@ def _parse_issue_activity(issue_activity_str):
         sys.exit(msg)
 
     issue_dicts = issue_activity["nodes"]
-    issues_owned = [
-        id for id in issue_dicts
-        if id["repository"]["owner"]["login"] == pdata.username
-    ]
-    issues_orgs = [
-         id for id in issue_dicts
-         if id["repository"]["owner"]["login"] in pdata.orgs
-    ]
-    issues_external = [
-         id for id in issue_dicts
-         if id not in issues_owned
-         and id not in issues_orgs
-    ]
+    issues_owned, issues_orgs, issues_external = _classify_repos(
+        issue_dicts, pdata.username, pdata.orgs
+    )
 
-    # DEV: Should we be dealing with pagination?
-    # When does issueCount != len(issue_dicts)?
-    pdata.new_issue_count = issue_activity["issueCount"]
+    # The search API caps results at 100 nodes, but issueCount can report a
+    # higher number. Report what we actually analyzed, so the count always
+    # matches the rest of the issue analysis.
+    pdata.new_issue_count = len(issue_dicts)
 
     pdata.issues_owned = len(issues_owned)
     pdata.issues_orgs = len(issues_orgs)

--- a/src/gh_profiler/utils/repo_fetching.py
+++ b/src/gh_profiler/utils/repo_fetching.py
@@ -1,7 +1,6 @@
 """Utils for retrieving repo information when targeting a URL."""
 
 import json
-import sys
 from concurrent.futures import ThreadPoolExecutor
 from textwrap import dedent
 from time import perf_counter
@@ -11,8 +10,6 @@ from . import infra_utils
 from .profile_data import profile_data as pdata
 from .repo_data import repo_data, PRData
 from .cli_config import cli_config
-
-import httpx2
 
 
 def get_data():
@@ -24,17 +21,11 @@ def get_data():
     Fetch all data we'll need, then parse it into the data structures that
     can be analyzed and processed.
     """
-    # Fetch data. This can all be done in parallel. The benchmarking is here
-    # because this is the slowest part of the program, and it's helpful at
-    # times to benchmark just this fetching code.
+    # Fetch data. The benchmarking is here because this is the slowest part of
+    # the program, and it's helpful at times to benchmark just this fetching code.
     ts_before = perf_counter()
     with ThreadPoolExecutor() as executor:
-        # Make fetching calls.
-        # reachable_future = executor.submit(_fetch_reachable)
         prs_future = executor.submit(_fetch_prs)
-
-        # When each call finishes, store the result.
-        # reachable_str = reachable_future.result()
         prs_obj = prs_future.result()
 
     ts_after = perf_counter()
@@ -42,30 +33,12 @@ def get_data():
         print(f"Fetch data: {ts_after - ts_before:.2f} seconds")
 
     # Parse data. This should only happen after all data has been fetched.
-    # _parse_reachable(reachable_str)
     target_prs = _parse_prs(prs_obj)
 
     return target_prs
 
 
 # --- Helper functions ---
-
-def _fetch_reachable():
-    """Fetch page at URL.
-    
-    Make sure this URL is reachable.
-    """
-    r = httpx2.get(cli_config.url)
-    return r.status_code
-
-def _parse_reachable(reachable_str):
-    """Parse output of reachable call."""
-    if reachable_str == 200:
-        return
-
-    msg = f"URL returned status code {reachable_str}."
-    msg += "\n  Is the URL correct?"
-    sys.exit(msg)
 
 def _fetch_prs():
     """Fetch relevant PRs.

--- a/src/gh_profiler/utils/repo_summary.py
+++ b/src/gh_profiler/utils/repo_summary.py
@@ -1,9 +1,0 @@
-"""Utils for summarizing bulk PRs."""
-
-
-
-
-def show_summary(target_prs):
-    """Show summary for all processed PRs."""
-    for pr in target_prs:
-        print(pr.summary)

--- a/src/gh_profiler/utils/workflow_utils.py
+++ b/src/gh_profiler/utils/workflow_utils.py
@@ -84,7 +84,7 @@ def _get_workflow_path():
 
     # If there's no .git directory, we probably shouldn't proceed.
     if not path_git_dir.exists() or not path_git_dir.is_dir():
-        msg = f"Could not find a .git dir at: {path_cwd.as_posix()}"
+        msg = f"Could not find a .git dir at: {Path.cwd().as_posix()}"
         msg += "\nAre you in the root directory of your project's repository?"
         sys.exit(msg)
 
@@ -106,15 +106,10 @@ def _confirm_write_workflow(path_workflow, workflow_choice):
 
     msg += "\n\nThe workflow will be written at the following location:"
     msg += f"\n  {path_workflow.as_posix()}"
-    msg += "\n\nAre you sure you want to do this? (y/n) "
+    msg += "\n\nAre you sure you want to do this?"
 
-    confirmed = ""
-    while confirmed.lower() not in ("y", "yes", "n", "no"):
-        confirmed = input(msg)
-        if confirmed.lower() in ("y", "yes"):
-            return
-        elif confirmed.lower() in ("n", "no"):
-            sys.exit()
+    if not click.confirm(msg):
+        sys.exit()
 
 def _write_workflow(path_workflow, workflow_choice):
     """Write the workflow file to the correct location."""

--- a/tests/e2e_tests/test_profiler.py
+++ b/tests/e2e_tests/test_profiler.py
@@ -20,7 +20,7 @@ def run_with_timeout(cmd):
     num_attempts = 0
     while num_attempts < 5:
         try:
-            result = infra_utils.run_cmd(cmd, timeout=5)
+            result = infra_utils.run_cmd(cmd, timeout=20)
             output = result.stdout
         except subprocess.TimeoutExpired:
             print("Time out.")

--- a/tests/unit_tests/test_cli_utils.py
+++ b/tests/unit_tests/test_cli_utils.py
@@ -1,0 +1,27 @@
+"""Tests for CLI helper functions."""
+
+import pytest
+
+from gh_profiler.utils import cli_utils
+from gh_profiler.utils import infra_utils
+
+
+def _fake_run_cmd(stdout, returncode=0):
+    return lambda cmd: infra_utils.CommandResult(stdout=stdout, stderr="", returncode=returncode)
+
+
+def test_get_repo_slug_strips_whitespace(monkeypatch):
+    """A repo slug should not carry trailing whitespace from gh."""
+    monkeypatch.setattr(cli_utils, "run_cmd", _fake_run_cmd("owner/repo\n"))
+
+    assert cli_utils._get_repo_slug() == "owner/repo"
+
+
+def test_get_repo_slug_blank_output(monkeypatch):
+    """Blank output should exit with a helpful message."""
+    monkeypatch.setattr(cli_utils, "run_cmd", _fake_run_cmd("   "))
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_utils._get_repo_slug()
+
+    assert "Couldn't determine the default GitHub repository" in str(exc_info.value)

--- a/tests/unit_tests/test_infra_utils.py
+++ b/tests/unit_tests/test_infra_utils.py
@@ -1,0 +1,35 @@
+"""Tests for running subprocess commands."""
+
+import sys
+
+from gh_profiler.utils import infra_utils
+
+
+def _exe():
+    """Path to the current interpreter, in a form shlex.split won't mangle.
+
+    shlex treats backslashes as escape characters, so a Windows path needs
+    forward slashes here.
+    """
+    return sys.executable.replace("\\", "/")
+
+
+def test_run_cmd_handles_non_utf8_output():
+    """A subprocess that emits non-UTF-8 bytes should not crash.
+
+    gh on Windows can print text in the local codepage, which isn't valid
+    UTF-8. We replace the offending bytes rather than raising.
+    """
+    cmd = f'{_exe()} -c "import sys; sys.stdout.buffer.write(bytes([0x61, 0x85]))"'
+    result = infra_utils.run_cmd(cmd)
+
+    assert result.returncode == 0
+    assert "\ufffd" in result.stdout
+
+
+def test_run_cmd_captures_stderr():
+    """Errors on stderr should be captured, not lost."""
+    cmd = f"{_exe()} -c \"import sys; sys.stderr.write('boom')\""
+    result = infra_utils.run_cmd(cmd)
+
+    assert "boom" in result.stderr

--- a/tests/unit_tests/test_profile_utils.py
+++ b/tests/unit_tests/test_profile_utils.py
@@ -1,0 +1,214 @@
+"""Tests for fetching and parsing user data from GitHub."""
+
+import pytest
+
+from gh_profiler.utils import infra_utils
+from gh_profiler.utils import profile_utils
+from gh_profiler.utils.profile_data import profile_data as pdata
+
+
+@pytest.fixture(autouse=True)
+def clean_pdata():
+    """Start each test with a fresh pdata, to avoid state leaking between tests."""
+    pdata.reset_fields()
+    pdata.username = "octocat"
+
+
+def _repo_node(owner, **kwargs):
+    """Build a minimal node with a repository owner."""
+    node = {"repository": {"owner": {"login": owner}}}
+    node.update(kwargs)
+    return node
+
+
+# --- _classify_repos ---
+
+def test_classify_repos_handles_case():
+    """Repo owner and org logins should match case-insensitively."""
+    nodes = [
+        _repo_node("octocat"),
+        _repo_node("OctoCat"),
+        _repo_node("acme"),
+        _repo_node("Acme"),
+        _repo_node("otheruser"),
+    ]
+
+    owned, in_orgs, external = profile_utils._classify_repos(nodes, "octocat", ["ACME"])
+
+    assert len(owned) == 2
+    assert len(in_orgs) == 2
+    assert len(external) == 1
+
+
+def test_classify_repos_no_orgs():
+    """A user with no orgs should still split owned from external."""
+    nodes = [_repo_node("octocat"), _repo_node("otheruser")]
+
+    owned, in_orgs, external = profile_utils._classify_repos(nodes, "octocat", [])
+
+    assert len(owned) == 1
+    assert len(in_orgs) == 0
+    assert len(external) == 1
+
+
+# --- _parse_pr_activity ---
+
+def test_parse_pr_activity_counts():
+    """Counts should reflect owned, org, and external PR buckets."""
+    prs_json = {
+        "data": {
+            "search": {
+                "nodes": [
+                    _repo_node("octocat", mergedAt=None, state="OPEN"),
+                    _repo_node("acme", mergedAt=None, state="OPEN"),
+                    _repo_node("other1", mergedAt="2024-01-01T00:00:00Z", state="MERGED"),
+                    _repo_node("other2", mergedAt=None, state="CLOSED"),
+                ]
+            }
+        }
+    }
+    pdata.orgs = ["ACME"]
+
+    profile_utils._parse_pr_activity(__import__("json").dumps(prs_json))
+
+    assert pdata.opened_count == 4
+    assert pdata.opened_count_owned == 1
+    assert pdata.opened_count_orgs == 1
+    assert pdata.opened_count_external == 2
+    assert pdata.merged_count_external == 1
+    assert pdata.closed_count_external == 1
+
+
+# --- _parse_issue_activity ---
+
+def test_parse_issue_activity_counts():
+    """Issue buckets, NOT_PLANNED, and repeated titles should all be found."""
+    issues_json = {
+        "data": {
+            "search": {
+                "nodes": [
+                    _repo_node("octocat", stateReason=None, title="My own issue"),
+                    _repo_node("acme", stateReason=None, title="Org issue"),
+                    _repo_node("other1", stateReason="NOT_PLANNED", title="Spam title"),
+                    _repo_node("other2", stateReason=None, title="Spam title"),
+                    _repo_node("other3", stateReason=None, title="Unique title"),
+                ]
+            }
+        }
+    }
+    pdata.orgs = ["ACME"]
+
+    profile_utils._parse_issue_activity(__import__("json").dumps(issues_json))
+
+    assert pdata.new_issue_count == 5
+    assert pdata.issues_owned == 1
+    assert pdata.issues_orgs == 1
+    assert pdata.issues_external == 3
+    assert pdata.issues_not_planned == 1
+    assert pdata.total_repeats == 2
+    assert pdata.repeated_issue_titles == {"Spam title": 2}
+
+
+def test_parse_issue_activity_matches_analyzed_nodes():
+    """new_issue_count should match what we actually analyzed, not issueCount.
+
+    The search API caps results at 100, so a large issueCount could disagree
+    with the nodes we got back. Reporting the node count keeps the numbers
+    consistent with the rest of the analysis.
+    """
+    issues_json = {
+        "data": {
+            "search": {
+                "issueCount": 5,
+                "nodes": [
+                    _repo_node("other1", stateReason=None, title="A"),
+                    _repo_node("other2", stateReason=None, title="B"),
+                ],
+            }
+        }
+    }
+    pdata.orgs = []
+
+    profile_utils._parse_issue_activity(__import__("json").dumps(issues_json))
+
+    assert pdata.new_issue_count == 2
+
+
+# --- _run_gh_cmd ---
+
+def test_run_gh_cmd_success(monkeypatch):
+    """A successful command returns its result."""
+    result = infra_utils.CommandResult(stdout="{}", stderr="", returncode=0)
+    monkeypatch.setattr(infra_utils, "run_cmd", lambda cmd: result)
+
+    returned = profile_utils._run_gh_cmd("gh api x", "test")
+
+    assert returned is result
+
+
+def test_run_gh_cmd_failure_raises(monkeypatch):
+    """A failed command raises ValueError with gh's stderr."""
+    result = infra_utils.CommandResult(stdout="", stderr="gh: Not Found (HTTP 404)", returncode=1)
+    monkeypatch.setattr(infra_utils, "run_cmd", lambda cmd: result)
+
+    with pytest.raises(ValueError, match="404"):
+        profile_utils._run_gh_cmd("gh api x", "test")
+
+
+# --- get_data ---
+
+def test_get_data_end_to_end(monkeypatch):
+    """A full get_data run should parse everything from the fake gh calls."""
+    profile_json = '{"login":"octocat","name":"Octo","created_at":"2020-01-01T00:00:00Z","company":null,"blog":"","location":null,"email":null,"bio":null}'
+    orgs_json = '[{"login":"ACME","description":null,"url":"x"}]'
+    socials_json = "[]"
+    prs_json = __import__("json").dumps({
+        "data": {"search": {"nodes": [_repo_node("other1", mergedAt=None, state="CLOSED")]}}
+    })
+    issues_json = __import__("json").dumps({
+        "data": {"search": {"nodes": [_repo_node("other1", stateReason="NOT_PLANNED", title="T")]}}
+    })
+
+    def fake_run_cmd(cmd):
+        if "auth status" in cmd:
+            return infra_utils.CommandResult(stdout="Logged in to github.com as octocat\n", stderr="", returncode=0)
+        if "--jq" in cmd and "orgs" in cmd:
+            return infra_utils.CommandResult(stdout=orgs_json, stderr="", returncode=0)
+        if "social_accounts" in cmd:
+            return infra_utils.CommandResult(stdout=socials_json, stderr="", returncode=0)
+        if "is:pull-request" in cmd:
+            return infra_utils.CommandResult(stdout=prs_json, stderr="", returncode=0)
+        if "is:issue" in cmd:
+            return infra_utils.CommandResult(stdout=issues_json, stderr="", returncode=0)
+        if "users/octocat" in cmd:
+            return infra_utils.CommandResult(stdout=profile_json, stderr="", returncode=0)
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(infra_utils, "run_cmd", fake_run_cmd)
+
+    profile_utils.get_data()
+
+    assert pdata.orgs == ["ACME"]
+    assert pdata.opened_count == 1
+    assert pdata.opened_count_external == 1
+    assert pdata.new_issue_count == 1
+    assert pdata.issues_not_planned == 1
+
+
+def test_get_data_failed_fetch_exits_cleanly(monkeypatch):
+    """A failed gh call should exit with a message, not crash with a traceback."""
+    profile_json = '{"login":"octocat","created_at":"2020-01-01T00:00:00Z"}'
+
+    def fake_run_cmd(cmd):
+        if "auth status" in cmd:
+            return infra_utils.CommandResult(stdout="Logged in to github.com as octocat\n", stderr="", returncode=0)
+        if "orgs" in cmd:
+            return infra_utils.CommandResult(stdout="", stderr="gh: rate limit exceeded", returncode=1)
+        if "users/octocat" in cmd:
+            return infra_utils.CommandResult(stdout=profile_json, stderr="", returncode=0)
+        return infra_utils.CommandResult(stdout="{}", stderr="", returncode=0)
+
+    monkeypatch.setattr(infra_utils, "run_cmd", fake_run_cmd)
+
+    with pytest.raises(SystemExit):
+        profile_utils.get_data()

--- a/tests/unit_tests/test_repo_analysis.py
+++ b/tests/unit_tests/test_repo_analysis.py
@@ -1,0 +1,49 @@
+"""Tests for analyzing repo data in bulk processing."""
+
+from gh_profiler.utils import repo_analysis
+from gh_profiler.utils.profile_data import profile_data as pdata
+from gh_profiler.utils.repo_data import PRData
+
+
+def test_adjust_author_summary_drops_closing_line():
+    """The bulk version should not carry the 'run a detailed report' line."""
+    pdata.username = "alice"
+    concise = (
+        "GitHub user: alice\n"
+        "🟢 No concerns found with user's profile.\n"
+        "🟢 No concerns found with recent PR activity.\n"
+        "🟢 No concerns found with recent issue activity.\n"
+        "\nFor a more detailed report, run `gh-profiler alice`."
+    )
+
+    adjusted = repo_analysis._adjust_author_summary(concise)
+
+    assert "For a more detailed report" not in adjusted
+    assert adjusted.splitlines()[0] == "  GitHub user: alice"
+
+
+def test_get_cached_author_info():
+    """A second PR from the same author should reuse the first profile."""
+    prs = [
+        PRData(pr_num=1, author="alice"),
+        PRData(
+            pr_num=2,
+            author="alice",
+            author_summary="summary text",
+            profile_flag="\U0001f7e2",
+            pr_flag="\U0001f7e1",
+            issue_flag="\U0001f7e2",
+        ),
+        PRData(pr_num=3, author="bob"),
+    ]
+
+    info = repo_analysis._get_cached_author_info("alice", prs)
+
+    assert info == ("summary text", "\U0001f7e2", "\U0001f7e1", "\U0001f7e2")
+
+
+def test_get_cached_author_info_no_match():
+    """An author with no cached profile should return None."""
+    prs = [PRData(pr_num=1, author="alice")]
+
+    assert repo_analysis._get_cached_author_info("bob", prs) is None

--- a/tests/unit_tests/test_repo_fetching.py
+++ b/tests/unit_tests/test_repo_fetching.py
@@ -1,0 +1,67 @@
+"""Tests for fetching and parsing repo-level data."""
+
+import json
+
+from gh_profiler.utils import infra_utils
+from gh_profiler.utils import repo_fetching
+from gh_profiler.utils.cli_config import cli_config
+
+
+def _pr_node(number, title, author, closed_at, merged=False):
+    return {
+        "number": number,
+        "title": title,
+        "state": "MERGED" if merged else "CLOSED",
+        "merged": merged,
+        "createdAt": "2024-01-01T00:00:00Z",
+        "closedAt": closed_at,
+        "mergedAt": "2024-01-01T00:00:00Z" if merged else None,
+        "url": f"https://github.com/owner/repo/pull/{number}",
+        "author": {"login": author},
+    }
+
+
+def test_parse_prs(monkeypatch):
+    """Open PRs should parse into PRData objects in order."""
+    cli_config.back = False
+    cli_config.num_targets = 10
+
+    nodes = [
+        _pr_node(1, "First PR", "alice", None),
+        _pr_node(2, "Second PR", "bob", None),
+    ]
+    response = infra_utils.CommandResult(
+        stdout=json.dumps({"data": {"repository": {"pullRequests": {"nodes": nodes}}}}),
+        stderr="",
+        returncode=0,
+    )
+
+    target_prs = repo_fetching._parse_prs(response)
+
+    assert [pr.pr_num for pr in target_prs] == [1, 2]
+    assert [pr.author for pr in target_prs] == ["alice", "bob"]
+    assert target_prs[0].title == "First PR"
+    assert target_prs[0].merged is None
+
+
+def test_parse_prs_back_uses_closed_at(monkeypatch):
+    """When looking back, PRs should be sorted by closedAt and capped."""
+    cli_config.back = True
+    cli_config.num_targets = 2
+
+    nodes = [
+        _pr_node(1, "Old", "alice", "2024-01-01T00:00:00Z"),
+        _pr_node(2, "New", "bob", "2024-03-01T00:00:00Z", merged=True),
+        _pr_node(3, "Middle", "carol", "2024-02-01T00:00:00Z"),
+    ]
+    response = infra_utils.CommandResult(
+        stdout=json.dumps({"data": {"repository": {"pullRequests": {"nodes": nodes}}}}),
+        stderr="",
+        returncode=0,
+    )
+
+    target_prs = repo_fetching._parse_prs(response)
+
+    assert [pr.pr_num for pr in target_prs] == [2, 3]
+    assert target_prs[0].merged is True
+    assert target_prs[1].merged is False

--- a/tests/unit_tests/test_workflow_utils.py
+++ b/tests/unit_tests/test_workflow_utils.py
@@ -1,0 +1,33 @@
+"""Tests for writing a workflow file."""
+
+from pathlib import Path
+
+import pytest
+
+from gh_profiler.utils import workflow_utils
+
+
+def test_get_workflow_path_no_conflicts(tmp_path, monkeypatch):
+    """If .github/workflows exists and the file is new, use that path."""
+    workflows_dir = tmp_path / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(tmp_path)
+
+    path = workflow_utils._get_workflow_path()
+
+    assert path == workflows_dir / "profile_contributors.yml"
+
+
+def test_get_workflow_path_missing_git_dir(tmp_path, monkeypatch):
+    """Without a .git dir, exit with a helpful message instead of a NameError.
+
+    This is a regression test: this path used to reference an undefined
+    `path_cwd` variable and crash.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        workflow_utils._get_workflow_path()
+
+    assert "Could not find a .git dir" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -3,20 +3,6 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -42,7 +28,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -64,7 +50,6 @@ version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "httpx2" },
     { name = "humanize" },
     { name = "rich" },
 ]
@@ -79,7 +64,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
-    { name = "httpx2", specifier = ">=2.3.0" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "rich", specifier = ">=15.0.0" },
 ]
@@ -92,58 +76,12 @@ dev = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "httpcore2"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/34/18f1c596e677962f040284246f393b10a1f8ce440b3a7e69c637d0f1c7ad/httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924", size = 64300, upload-time = "2026-06-01T13:15:02.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415", size = 80024, upload-time = "2026-06-01T13:15:00.001Z" },
-]
-
-[[package]]
-name = "httpx2"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
-    { name = "idna" },
-    { name = "truststore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/9a/cca0b9145f13d8ae34b885ae28d403a1469a433abc78e0f94f4ce94e650b/httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9", size = 81115, upload-time = "2026-06-01T13:15:04.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7", size = 74538, upload-time = "2026-06-01T13:15:01.566Z" },
-]
-
-[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -299,15 +237,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
-]
-
-[[package]]
-name = "truststore"
-version = "0.10.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What's here:
- Fix \path_cwd\ NameError in workflow generation.
- Fix \_get_repo_slug\ whitespace handling.
- Align case-insensitive owned/org repo matching between PR and issue parsing.
- Make fetch failures surface real gh errors instead of blaming timeouts.
- Per-call error guarding in the fetch thread pool.
- Remove dead reachability code, the \httpx2\ dependency, and unused \epo_summary.py\.
- Two Windows fixes: tolerate non-UTF-8 gh output, and force UTF-8 stdout so emoji flags print.
- \-n\/\--num-targets\ now requires at least 1.
- Add unit tests for previously untested modules (38 -> 58 tests total), and bump the e2e timeout from 5s to 20s.

Full background in documentation.md.